### PR TITLE
Upgrader done.inc.php: scp/settings.php not working

### DIFF
--- a/include/upgrader/done.inc.php
+++ b/include/upgrader/done.inc.php
@@ -25,7 +25,7 @@ $_SESSION['ost_upgrader']=null;
             <h3><?php echo __("What's Next?");?></h3>
             <p><b><?php echo __('Post-upgrade');?></b>: <?php
             echo sprintf(__('You can now go to %s to enable the system and explore the new features. For complete and up-to-date release notes see the %s'),
-                sprintf('<a href="scp/settings.php" target="_blank">%s</a>', __('Admin Panel')),
+                sprintf('<a href="settings.php" target="_blank">%s</a>', __('Admin Panel')),
                 sprintf('<a href="http://osticket.com/wiki/Release_Notes" target="_blank">%s</a>', __('osTicket Wiki')));?></p>
             <p><b><?php echo __('Stay up to date');?></b>: <?php echo __("It's important to keep your osTicket installation up to date. Get announcements, security updates and alerts delivered directly to you!");?>
             <?php echo sprintf(__('%1$s Get in the loop %2$s today and stay informed!'), '<a target="_blank" href="http://osticket.com/subscribe.php">', '</a>');?></p>

--- a/include/upgrader/done.inc.php
+++ b/include/upgrader/done.inc.php
@@ -25,7 +25,7 @@ $_SESSION['ost_upgrader']=null;
             <h3><?php echo __("What's Next?");?></h3>
             <p><b><?php echo __('Post-upgrade');?></b>: <?php
             echo sprintf(__('You can now go to %s to enable the system and explore the new features. For complete and up-to-date release notes see the %s'),
-                sprintf('<a href="settings.php" target="_blank">%s</a>', __('Admin Panel')),
+                sprintf('<a href="'. ROOT_PATH . 'scp/settings.php" target="_blank">%s</a>', __('Admin Panel')),
                 sprintf('<a href="http://osticket.com/wiki/Release_Notes" target="_blank">%s</a>', __('osTicket Wiki')));?></p>
             <p><b><?php echo __('Stay up to date');?></b>: <?php echo __("It's important to keep your osTicket installation up to date. Get announcements, security updates and alerts delivered directly to you!");?>
             <?php echo sprintf(__('%1$s Get in the loop %2$s today and stay informed!'), '<a target="_blank" href="http://osticket.com/subscribe.php">', '</a>');?></p>


### PR DESCRIPTION
Hey guys,

just found out that the link here is not working: scp/settings.php
The full link looks like: http://my-server.com/osticket/scp/scp/settings.php

First I thought that the leading slash is missing, but this resulted also in a not working link: /scp/settings.php
The full link misses the "osticket" directory: http://my-server.com/scp/settings.php

Finally I decided to just use "settings.php" which worked and showed a correct link:
http://my-server.com/osticket/scp/settings.php

Greetings
Michael

PS: Don't know if it should be just "settings.php" - but that is working ;)