### PR TITLE
Help topics have much better form configurations

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -116,6 +116,7 @@ class Bootstrap {
         define('FORM_ANSWER_TABLE',$prefix.'form_entry_values');
 
         define('TOPIC_TABLE',$prefix.'help_topic');
+        define('TOPIC_FORM_TABLE',$prefix.'help_topic_form');
         define('SLA_TABLE', $prefix.'sla');
 
         define('EMAIL_TABLE',$prefix.'email');

--- a/include/ajax.forms.php
+++ b/include/ajax.forms.php
@@ -24,13 +24,13 @@ class DynamicFormsAjaxAPI extends AjaxController {
             $_SESSION[':form-data'] = array_merge($_SESSION[':form-data'], $_GET);
         }
 
-        if ($form = $topic->getForm()) {
+        foreach ($topic->getForms() as $form) {
             ob_start();
             $form->getForm($_SESSION[':form-data'])->render(!$client);
-            $html = ob_get_clean();
+            $html .= ob_get_clean();
             ob_start();
             print $form->getMedia();
-            $media = ob_get_clean();
+            $media .= ob_get_clean();
         }
         return $this->encode(array(
             'media' => $media,
@@ -139,6 +139,24 @@ class DynamicFormsAjaxAPI extends AjaxController {
         return JsonDataEncoder::encode(
             array('id'=>$field->ajaxUpload(true))
         );
+    }
+
+    function getAllFields($id) {
+        global $thisstaff;
+
+        if (!$thisstaff)
+            Http::response(403, 'Login required');
+        elseif (!$form = DynamicForm::lookup($id))
+            Http::response(400, 'No such form');
+
+        ob_start();
+        include STAFFINC_DIR . 'templates/dynamic-form-fields-view.tmpl.php';
+        $html = ob_get_clean();
+
+        return $this->encode(array(
+            'success'=>true,
+            'html' => $html,
+        ));
     }
 }
 ?>

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1076,7 +1076,7 @@ class Ticket {
     function setStatus($status, $comments='', &$errors=array(), $set_closing_agent=true) {
         global $thisstaff;
 
-        if (!$thisstaff || !($role=$thisstaff->getRole($this->getDeptId())))
+        if ($thisstaff && !($role=$thisstaff->getRole($this->getDeptId())))
             return false;
 
         if ($status && is_numeric($status))
@@ -1085,19 +1085,21 @@ class Ticket {
         if (!$status || !$status instanceof TicketStatus)
             return false;
 
-        // Double check permissions
-        switch ($status->getState()) {
-        case 'closed':
-            if (!($role->hasPerm(TicketModel::PERM_CLOSE)))
+        // Double check permissions (when changing status)
+        if ($this->getStatusId()) {
+            switch ($status->getState()) {
+            case 'closed':
+                if (!($role->hasPerm(TicketModel::PERM_CLOSE)))
+                    return false;
+                break;
+            case 'deleted':
+                // XXX: intercept deleted status and do hard delete
+                if ($role->hasPerm(TicketModel::PERM_DELETE))
+                    return $this->delete($comments);
+                // Agent doesn't have permission to delete  tickets
                 return false;
-            break;
-        case 'deleted':
-            // XXX: intercept deleted status and do hard delete
-            if ($role->hasPerm(TicketModel::PERM_DELETE))
-                return $this->delete($comments);
-            // Agent doesn't have permission to delete  tickets
-            return false;
-            break;
+                break;
+            }
         }
 
         if ($this->getStatusId() == $status->getId())
@@ -1244,10 +1246,14 @@ class Ticket {
                 return false;  //bail out...missing stuff.
         }
 
-        $options = array(
-            'inreplyto'=>$message->getEmailMessageId(),
-            'references'=>$message->getEmailReferences(),
-            'thread'=>$message);
+        $options = array();
+        if ($message instanceof ThreadEntry) {
+            $options += array(
+                'inreplyto'=>$message->getEmailMessageId(),
+                'references'=>$message->getEmailReferences(),
+                'thread'=>$message
+            );
+        }
 
         //Send auto response - if enabled.
         if($autorespond
@@ -1275,7 +1281,7 @@ class Ticket {
 
             $recipients=$sentlist=array();
             //Exclude the auto responding email just incase it's from staff member.
-            if ($message->isAutoReply())
+            if ($message instanceof ThreadEntry && $message->isAutoReply())
                 $sentlist[] = $this->getEmail();
 
             //Alert admin??
@@ -2019,7 +2025,7 @@ class Ticket {
         return $message;
     }
 
-    function postCannedReply($canned, $msgId, $alert=true) {
+    function postCannedReply($canned, $message, $alert=true) {
         global $ost, $cfg;
 
         if((!is_object($canned) && !($canned=Canned::lookup($canned))) || !$canned->isEnabled())
@@ -2036,7 +2042,7 @@ class Ticket {
             $response = new TextThreadEntryBody(
                     $this->replaceVars($canned->getPlainText()));
 
-        $info = array('msgId' => $msgId,
+        $info = array('msgId' => $message instanceof ThreadEntry ? $message->getId() : 0,
                       'poster' => __('SYSTEM (Canned Reply)'),
                       'response' => $response,
                       'cannedattachments' => $files);
@@ -2715,15 +2721,11 @@ class Ticket {
             }
         }
 
-        if (!$form->isValid($field_filter('ticket')))
-            $errors += $form->errors();
-
         if ($vars['uid'])
             $user = User::lookup($vars['uid']);
 
         $id=0;
         $fields=array();
-        $fields['message']  = array('type'=>'*',     'required'=>1, 'error'=>__('Message content is required'));
         switch (strtolower($origin)) {
             case 'web':
                 $fields['topicId']  = array('type'=>'int',  'required'=>1, 'error'=>__('Select a help topic'));
@@ -2756,11 +2758,11 @@ class Ticket {
                 $errors['duedate']=__('Due date must be in the future');
         }
 
+        $topic_forms = array();
         if (!$errors) {
 
             // Handle the forms associate with the help topics. Instanciate the
             // entries, disable and track the requested disabled fields.
-            $topic_forms = array();
             if ($vars['topicId']) {
                 if ($__topic=Topic::lookup($vars['topicId'])) {
                     foreach ($__topic->getForms() as $idx=>$__F) {
@@ -2845,6 +2847,9 @@ class Ticket {
                     $errors['user'] = __('Incomplete client information');
             }
         }
+
+        if (!$form->isValid($field_filter('ticket')))
+            $errors += $form->errors();
 
         if ($vars['topicId']) {
             if ($topic=Topic::lookup($vars['topicId'])) {
@@ -3065,12 +3070,12 @@ class Ticket {
         # not have a return 'ping' message
         if (isset($vars['flags']) && $vars['flags']['bounce'])
             $autorespond = false;
-        if ($autorespond && $message->isAutoReply())
+        if ($autorespond && $message instanceof ThreadEntry && $message->isAutoReply())
             $autorespond = false;
 
         //post canned auto-response IF any (disables new ticket auto-response).
         if ($vars['cannedResponseId']
-            && $ticket->postCannedReply($vars['cannedResponseId'], $message->getId(), $autorespond)) {
+            && $ticket->postCannedReply($vars['cannedResponseId'], $message, $autorespond)) {
                 $ticket->markUnAnswered(); //Leave the ticket as unanswred.
                 $autorespond = false;
         }
@@ -3082,7 +3087,7 @@ class Ticket {
 
         //Don't send alerts to staff when the message is a bounce
         //  this is necessary to avoid possible loop (especially on new ticket)
-        if ($alertstaff && $message->isBounce())
+        if ($alertstaff && $message instanceof ThreadEntry && $message->isBounce())
             $alertstaff = false;
 
         /***** See if we need to send some alerts ****/

--- a/include/class.topic.php
+++ b/include/class.topic.php
@@ -52,11 +52,15 @@ class Topic extends VerySimpleModel {
                     'priority_id' => 'Priority.priority_id',
                 ),
             ),
+            'forms' => array(
+                'reverse' => 'TopicFormModel.topic',
+                'null' => true,
+            ),
         ),
     );
 
     var $page;
-    var $form;
+    var $_forms;
 
     const DISPLAY_DISABLED = 2;
 
@@ -129,19 +133,15 @@ class Topic extends VerySimpleModel {
         return $this->page;
     }
 
-    function getFormId() {
-        return $this->form_id;
-    }
-
-    function getForm() {
-        $id = $this->getFormId();
-
-        if ($id == self::FORM_USE_PARENT && ($p = $this->getParent()))
-            $this->form = $p->getForm();
-        elseif ($id && !$this->form)
-            $this->form = DynamicForm::lookup($id);
-
-        return $this->form;
+    function getForms() {
+        if (!isset($this->_forms)) {
+            foreach ($this->forms->select_related('form') as $F) {
+                $extra = JsonDataParser::decode($F->extra) ?: array();
+                $F->form->disableFields($extra['disable'] ?: array());
+                $this->_forms[] = $F->form;
+            }
+        }
+        return $this->_forms;
     }
 
     function autoRespond() {
@@ -426,10 +426,61 @@ class Topic extends VerySimpleModel {
             $errors['err']=sprintf(__('Unable to update %s.'), __('this help topic'))
             .' '.__('Internal error occurred');
         }
-        if (!$cfg || $cfg->getTopicSortMode() == 'a') {
-            static::updateSortOrder();
+        if ($rv) {
+            if (!$cfg || $cfg->getTopicSortMode() == 'a') {
+                static::updateSortOrder();
+            }
+            $this->updateForms($vars, $errors);
         }
         return $rv;
+    }
+
+    function updateForms($vars, &$errors) {
+        $find_disabled = function($form) use ($vars) {
+            $fields = $vars['fields'];
+            $disabled = array();
+            foreach ($form->fields->values_flat('id') as $row) {
+                list($id) = $row;
+                if (false === ($idx = array_search($id, $fields))) {
+                    $disabled[] = $id;
+                }
+            }
+            return $disabled;
+        };
+
+        // Consider all the forms in the request
+        if (is_array($form_ids = $vars['forms'])) {
+            $forms = TopicFormModel::objects()
+                ->select_related('form')
+                ->filter(array('topic_id' => $this->getId()));
+            foreach ($forms as $F) {
+                if (false !== ($idx = array_search($F->form_id, $form_ids))) {
+                    $F->sort = $idx + 1;
+                    $F->extra = JsonDataEncoder::encode(
+                        array('disable' => $find_disabled($F->form))
+                    );
+                    $F->save();
+                    unset($form_ids[$idx]);
+                }
+                elseif ($F->form->get('type') != 'T') {
+                    $F->delete();
+                }
+            }
+            foreach ($form_ids as $sort=>$id) {
+                if (!($form = DynamicForm::lookup($id))) {
+                    continue;
+                }
+                TopicFormModel::create(array(
+                    'topic_id' => $this->getId(),
+                    'form_id' => $id,
+                    'sort' => $sort + 1,
+                    'extra' => JsonDataEncoder::encode(
+                        array('disable' => $find_disabled($form))
+                    )
+                ))->save();
+            }
+        }
+        return true;
     }
 
     function save($refetch=false) {
@@ -473,3 +524,19 @@ class Topic extends VerySimpleModel {
 
 // Add fields from the standard ticket form to the ticket filterable fields
 Filter::addSupportedMatches(/* @trans */ 'Help Topic', array('topicId' => 'Topic ID'), 100);
+
+class TopicFormModel extends VerySimpleModel {
+    static $meta = array(
+        'table' => TOPIC_FORM_TABLE,
+        'pk' => array('id'),
+        'ordering' => array('sort'),
+        'joins' => array(
+            'topic' => array(
+                'constraint' => array('topic_id' => 'Topic.topic_id'),
+            ),
+            'form' => array(
+                'constraint' => array('form_id' => 'DynamicForm.id'),
+            ),
+        ),
+    );
+}

--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -13,11 +13,14 @@ $form = null;
 if (!$info['topicId'])
     $info['topicId'] = $cfg->getDefaultTopicId();
 
+$forms = array();
 if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
-    $form = $topic->getForm();
-    if ($_POST && $form) {
-        $form = $form->instanciate();
-        $form->isValidForClient();
+    foreach ($topic->getForms() as $F) {
+        if ($_POST) {
+            $F = $F->instanciate();
+            $F->isValidForClient();
+        }
+        $forms[] = $F;
     }
 }
 
@@ -29,9 +32,26 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
   <input type="hidden" name="a" value="open">
   <table width="800" cellpadding="1" cellspacing="0" border="0">
     <tbody>
+<?php
+        if (!$thisclient) {
+            $uform = UserForm::getUserForm()->getForm($_POST);
+            if ($_POST) $uform->isValid();
+            $uform->render(false);
+        }
+        else { ?>
+            <tr><td colspan="2"><hr /></td></tr>
+        <tr><td><?php echo __('Email'); ?>:</td><td><?php echo $thisclient->getEmail(); ?></td></tr>
+        <tr><td><?php echo __('Client'); ?>:</td><td><?php echo $thisclient->getName(); ?></td></tr>
+        <?php } ?>
+    </tbody>
+    <tbody>
+    <tr><td colspan="2"><hr />
+        <div class="form-header" style="margin-bottom:0.5em">
+        <b><?php echo __('Help Topic'); ?></b>
+        </div>
+    </td></tr>
     <tr>
-        <td class="required"><?php echo __('Help Topic');?>:</td>
-        <td>
+        <td colspan="2">
             <select id="topicId" name="topicId" onchange="javascript:
                     var data = $(':input[name]', '#dynamic-form').serialize();
                     $.ajax(
@@ -59,27 +79,11 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
             <font class="error">*&nbsp;<?php echo $errors['topicId']; ?></font>
         </td>
     </tr>
-<?php
-        if (!$thisclient) {
-            $uform = UserForm::getUserForm()->getForm($_POST);
-            if ($_POST) $uform->isValid();
-            $uform->render(false);
-        }
-        else { ?>
-            <tr><td colspan="2"><hr /></td></tr>
-        <tr><td><?php echo __('Email'); ?>:</td><td><?php echo $thisclient->getEmail(); ?></td></tr>
-        <tr><td><?php echo __('Client'); ?>:</td><td><?php echo $thisclient->getName(); ?></td></tr>
-        <?php } ?>
     </tbody>
     <tbody id="dynamic-form">
-        <?php if ($form) {
+        <?php foreach ($forms as $form) {
             include(CLIENTINC_DIR . 'templates/dynamic-form.tmpl.php');
         } ?>
-    </tbody>
-    <tbody><?php
-        $tform = TicketForm::getInstance()->getForm($_POST);
-        if ($_POST) $tform->isValid();
-        $tform->render(false); ?>
     </tbody>
     <tbody>
     <?php

--- a/include/staff/helptopic.inc.php
+++ b/include/staff/helptopic.inc.php
@@ -10,6 +10,7 @@ if($topic && $_REQUEST['a']!='add') {
     $info['pid']=$topic->getPid();
     $trans['name'] = $topic->getTranslateTag('name');
     $qs += array('id' => $topic->getId());
+    $forms = $topic->getForms();
 } else {
     $title=__('Add New Help Topic');
     $action='create';
@@ -21,22 +22,31 @@ if($topic && $_REQUEST['a']!='add') {
 }
 $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
 ?>
+
+<h2 style="font-weight: normal"><?php echo $title; ?>
+    &nbsp;<i class="help-tip icon-question-sign" href="#help_topic_information"></i>
+    </h2>
+<?php if ($topic) { ?>
+    <div class="big"><strong><?php echo $topic->getLocal('topic'); ?></strong></div>
+<?php } ?>
+
+<br/>
+
+<ul class="tabs" id="topic-tabs">
+    <li class="active"><a href="#info"><i class="icon-info-sign"></i> Help Topic Information</a></li>
+    <li><a href="#routing"><i class="icon-ticket"></i> New ticket options</a></li>
+    <li><a href="#forms"><i class="icon-paste"></i> Forms</a></li>
+</ul>
+
 <form action="helptopics.php?<?php echo Http::build_query($qs); ?>" method="post" id="save">
  <?php csrf_token(); ?>
  <input type="hidden" name="do" value="<?php echo $action; ?>">
  <input type="hidden" name="a" value="<?php echo Format::htmlchars($_REQUEST['a']); ?>">
  <input type="hidden" name="id" value="<?php echo $info['id']; ?>">
- <h2><?php echo __('Help Topic');?></h2>
- <table class="form_table" width="940" border="0" cellspacing="0" cellpadding="2">
-    <thead>
-        <tr>
-            <th colspan="2">
-                <h4><?php echo $title; ?></h4>
-                <em><?php echo __('Help Topic Information');?>
-                &nbsp;<i class="help-tip icon-question-sign" href="#help_topic_information"></i></em>
-            </th>
-        </tr>
-    </thead>
+
+<div id="topic-tabs_container">
+<div class="tab_content" id="info">
+ <table class="table" border="0" cellspacing="0" cellpadding="2">
     <tbody>
         <tr>
             <td width="180" class="required">
@@ -53,8 +63,8 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
                 <?php echo __('Status');?>:
             </td>
             <td>
-                <input type="radio" name="isactive" value="1" <?php echo $info['isactive']?'checked="checked"':''; ?>><?php echo __('Active'); ?>
-                <input type="radio" name="isactive" value="0" <?php echo !$info['isactive']?'checked="checked"':''; ?>><?php echo __('Disabled'); ?>
+                <input type="radio" name="isactive" value="1" <?php echo $info['isactive']?'checked="checked"':''; ?>> <?php echo __('Active'); ?>
+                <input type="radio" name="isactive" value="0" <?php echo !$info['isactive']?'checked="checked"':''; ?>> <?php echo __('Disabled'); ?>
                 &nbsp;<span class="error">*&nbsp;</span> <i class="help-tip icon-question-sign" href="#status"></i>
             </td>
         </tr>
@@ -63,8 +73,8 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
                 <?php echo __('Type');?>:
             </td>
             <td>
-                <input type="radio" name="ispublic" value="1" <?php echo $info['ispublic']?'checked="checked"':''; ?>><?php echo __('Public'); ?>
-                <input type="radio" name="ispublic" value="0" <?php echo !$info['ispublic']?'checked="checked"':''; ?>><?php echo __('Private/Internal'); ?>
+                <input type="radio" name="ispublic" value="1" <?php echo $info['ispublic']?'checked="checked"':''; ?>> <?php echo __('Public'); ?>
+                <input type="radio" name="ispublic" value="0" <?php echo !$info['ispublic']?'checked="checked"':''; ?>> <?php echo __('Private/Internal'); ?>
                 &nbsp;<span class="error">*&nbsp;</span> <i class="help-tip icon-question-sign" href="#type"></i>
             </td>
         </tr>
@@ -87,28 +97,26 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
             </td>
         </tr>
 
-        <tr><th colspan="2"><em><?php echo __('New ticket options');?></em></th></tr>
-        <tr>
-            <td><strong><?php echo __('Custom Form'); ?></strong>:</td>
-           <td><select name="form_id">
-                <option value="0" <?php
-if ($info['form_id'] == '0') echo 'selected="selected"';
-                    ?>>&mdash; <?php echo __('None'); ?> &mdash;</option>
-                <option value="<?php echo Topic::FORM_USE_PARENT; ?>"  <?php
-if ($info['form_id'] == Topic::FORM_USE_PARENT) echo 'selected="selected"';
-                    ?>>&mdash; <?php echo __('Use Parent Form'); ?> &mdash;</option>
-               <?php foreach (DynamicForm::objects()->filter(array('type'=>'G')) as $group) { ?>
-                <option value="<?php echo $group->get('id'); ?>"
-                       <?php if ($group->get('id') == $info['form_id'])
-                            echo 'selected="selected"'; ?>>
-                       <?php echo $group->get('title'); ?>
-                   </option>
-               <?php } ?>
-               </select>
-               &nbsp;<span class="error">&nbsp;<?php echo $errors['form_id']; ?></span>
-               <i class="help-tip icon-question-sign" href="#custom_form"></i>
-           </td>
-        </tr>
+    </tbody>
+    </table>
+
+        <div style="padding:8px 3px;border-bottom: 2px dotted #ddd;">
+            <strong class="big"><?php echo __('Internal Notes');?></strong><br/>
+            <?php echo __("be liberal, they're internal.");?>
+        </div>
+
+        <textarea class="richtext no-bar" name="notes" cols="21"
+            rows="8" style="width: 80%;"><?php echo $info['notes']; ?></textarea>
+
+</div>
+
+<div class="hidden tab_content" id="routing">
+<div style="padding:8px 0;border-bottom: 2px dotted #ddd;">
+<div><b class="big"><?php echo __('New ticket options');?></b></div>
+</div>
+
+ <table class="table" border="0" cellspacing="0" cellpadding="2">
+        <tbody>
         <tr>
             <td width="180" class="required">
                 <?php echo __('Department'); ?>:
@@ -127,6 +135,62 @@ if ($info['form_id'] == Topic::FORM_USE_PARENT) echo 'selected="selected"';
                 <i class="help-tip icon-question-sign" href="#department"></i>
             </td>
         </tr>
+        <tr class="border">
+            <td>
+                <?php echo __('Ticket Number Format'); ?>:
+            </td>
+            <td>
+                <label>
+                <input type="radio" name="custom-numbers" value="0" <?php echo !$info['custom-numbers']?'checked="checked"':''; ?>
+                    onchange="javascript:$('#custom-numbers').hide();"> <?php echo __('System Default'); ?>
+                </label>&nbsp;<label>
+                <input type="radio" name="custom-numbers" value="1" <?php echo $info['custom-numbers']?'checked="checked"':''; ?>
+                    onchange="javascript:$('#custom-numbers').show(200);"> <?php echo __('Custom'); ?>
+                </label>&nbsp; <i class="help-tip icon-question-sign" href="#custom_numbers"></i>
+            </td>
+        </tr>
+    </tbody>
+    <tbody id="custom-numbers" style="<?php if (!$info['custom-numbers']) echo 'display:none'; ?>">
+        <tr>
+            <td style="padding-left:20px">
+                <?php echo __('Format'); ?>:
+            </td>
+            <td>
+                <input type="text" name="number_format" value="<?php echo $info['number_format']; ?>"/>
+                <span class="faded"><?php echo __('e.g.'); ?> <span id="format-example"><?php
+                    if ($info['custom-numbers']) {
+                        if ($info['sequence_id'])
+                            $seq = Sequence::lookup($info['sequence_id']);
+                        if (!isset($seq))
+                            $seq = new RandomSequence();
+                        echo $seq->current($info['number_format']);
+                    } ?></span></span>
+                <div class="error"><?php echo $errors['number_format']; ?></div>
+            </td>
+        </tr>
+        <tr>
+<?php $selected = 'selected="selected"'; ?>
+            <td style="padding-left:20px">
+                <?php echo __('Sequence'); ?>:
+            </td>
+            <td>
+                <select name="sequence_id">
+                <option value="0" <?php if ($info['sequence_id'] == 0) echo $selected;
+                    ?>>&mdash; <?php echo __('Random'); ?> &mdash;</option>
+<?php foreach (Sequence::objects() as $s) { ?>
+                <option value="<?php echo $s->id; ?>" <?php
+                    if ($info['sequence_id'] == $s->id) echo $selected;
+                    ?>><?php echo $s->name; ?></option>
+<?php } ?>
+                </select>
+                <button class="action-button pull-right" onclick="javascript:
+                $.dialog('ajax.php/sequence/manage', 205);
+                return false;
+                "><i class="icon-gear"></i> <?php echo __('Manage'); ?></button>
+            </td>
+        </tr>
+    </tbody>
+    <tbody>
         <tr>
             <td width="180">
                 <?php echo __('Status'); ?>:
@@ -266,75 +330,90 @@ if ($info['form_id'] == Topic::FORM_USE_PARENT) echo 'selected="selected"';
                     <i class="help-tip icon-question-sign" href="#ticket_auto_response"></i>
             </td>
         </tr>
-        <tr>
-            <td>
-                <?php echo __('Ticket Number Format'); ?>:
-            </td>
-            <td>
-                <label>
-                <input type="radio" name="custom-numbers" value="0" <?php echo !$info['custom-numbers']?'checked="checked"':''; ?>
-                    onchange="javascript:$('#custom-numbers').hide();"> <?php echo __('System Default'); ?>
-                </label>&nbsp;<label>
-                <input type="radio" name="custom-numbers" value="1" <?php echo $info['custom-numbers']?'checked="checked"':''; ?>
-                    onchange="javascript:$('#custom-numbers').show(200);"> <?php echo __('Custom'); ?>
-                </label>&nbsp; <i class="help-tip icon-question-sign" href="#custom_numbers"></i>
-            </td>
-        </tr>
     </tbody>
-    <tbody id="custom-numbers" style="<?php if (!$info['custom-numbers']) echo 'display:none'; ?>">
+ </table>
+</div>
+
+<div class="hidden tab_content" id="forms">
+ <table id="topic-forms" class="table" border="0" cellspacing="0" cellpadding="2">
+
+<?php foreach ($forms as $F) { ?>
+    <tbody data-form-id="<?php echo $F->get('id'); ?>">
         <tr>
-            <td style="padding-left:20px">
-                <?php echo __('Format'); ?>:
-            </td>
-            <td>
-                <input type="text" name="number_format" value="<?php echo $info['number_format']; ?>"/>
-                <span class="faded"><?php echo __('e.g.'); ?> <span id="format-example"><?php
-                    if ($info['custom-numbers']) {
-                        if ($info['sequence_id'])
-                            $seq = Sequence::lookup($info['sequence_id']);
-                        if (!isset($seq))
-                            $seq = new RandomSequence();
-                        echo $seq->current($info['number_format']);
-                    } ?></span></span>
-                <div class="error"><?php echo $errors['number_format']; ?></div>
-            </td>
-        </tr>
-        <tr>
-<?php $selected = 'selected="selected"'; ?>
-            <td style="padding-left:20px">
-                <?php echo __('Sequence'); ?>:
-            </td>
-            <td>
-                <select name="sequence_id">
-                <option value="0" <?php if ($info['sequence_id'] == 0) echo $selected;
-                    ?>>&mdash; <?php echo __('Random'); ?> &mdash;</option>
-<?php foreach (Sequence::objects() as $s) { ?>
-                <option value="<?php echo $s->id; ?>" <?php
-                    if ($info['sequence_id'] == $s->id) echo $selected;
-                    ?>><?php echo $s->name; ?></option>
+            <td class="handle" colspan="6">
+                <input type="hidden" name="forms[]" value="<?php echo $F->get('id'); ?>" />
+                <div class="pull-right">
+                <i class="icon-2x icon-move icon-muted"></i>
+<?php if ($F->get('type') != 'T') { ?>
+                <a href="#" title="<?php echo __('Delete'); ?>" onclick="javascript:
+                if (confirm(__('You sure?')))
+                    var tbody = $(this).closest('tbody');
+                    tbody.fadeOut(function(){this.remove()});
+                    $(this).closest('form')
+                        .find('[name=form_id] [value=' + tbody.data('formId') + ']')
+                        .prop('disabled', false);
+                return false;"><i class="icon-2x icon-trash"></i></a>
 <?php } ?>
-                </select>
-                <button class="action-button pull-right" onclick="javascript:
-                $.dialog('ajax.php/sequence/manage', 205);
-                return false;
-                "><i class="icon-gear"></i> <?php echo __('Manage'); ?></button>
+                </div>
+                <div><strong><?php echo $F->getLocal('title'); ?></strong></div>
+                <div><?php echo $F->getLocal('instructions'); ?></div>
             </td>
         </tr>
-    </tbody>
-    <tbody>
         <tr>
-            <th colspan="2">
-                <em><strong><?php echo __('Internal Notes');?></strong>: <?php echo __("be liberal, they're internal.");?></em>
-            </th>
+            <th><?php echo __('Enable'); ?></th>
+            <th><?php echo __('Label'); ?></th>
+            <th><?php echo __('Type'); ?></th>
+            <th><?php echo __('Visibility'); ?></th>
+            <th><?php echo __('Variable'); ?></th>
         </tr>
+    <?php
+        foreach ($F->getFields() as $f) { ?>
         <tr>
-            <td colspan=2>
-                <textarea class="richtext no-bar" name="notes" cols="21"
-                    rows="8" style="width: 80%;"><?php echo $info['notes']; ?></textarea>
-            </td>
+            <td><input type="checkbox" name="fields[]" value="<?php
+                echo $f->get('id'); ?>" <?php
+                if ($f->isEnabled()) echo 'checked="checked"'; ?>/></td>
+            <td><?php echo $f->get('label'); ?></td>
+            <td><?php $t=FormField::getFieldType($f->get('type')); echo __($t[0]); ?></td>
+            <td><?php echo $f->getVisibilityDescription(); ?></td>
+            <td><?php echo $f->get('name'); ?></td>
         </tr>
+        <?php } ?>
     </tbody>
-</table>
+    <?php } ?>
+ </table>
+
+   <br/>
+   <strong><?php echo __('Add Custom Form'); ?></strong>:
+   <select name="form_id" onchange="javascript:
+    event.preventDefault();
+    var $this = $(this),
+        val = $this.val();
+    if (!val) return;
+    $.ajax({
+        url: 'ajax.php/form/' + val + '/fields/view',
+        dataType: 'json',
+        success: function(json) {
+            if (json.success) {
+                $(json.html).appendTo('#topic-forms').effect('highlight');
+                $this.find(':selected').prop('disabled', true);
+            }
+        }
+    });">
+    <option value=""><?php echo '— '.__('Add a custom form') . ' —'; ?></option>
+    <?php foreach (DynamicForm::objects()->filter(array('type'=>'G')) as $F) { ?>
+        <option value="<?php echo $F->get('id'); ?>"
+           <?php if ($F->get('id') == $info['form_id'])
+                echo 'selected="selected"'; ?>>
+           <?php echo $F->getLocal('title'); ?>
+        </option>
+    <?php } ?>
+   </select>
+   &nbsp;<span class="error">&nbsp;<?php echo $errors['form_id']; ?></span>
+   <i class="help-tip icon-question-sign" href="#custom_form"></i>
+</div>
+
+</div>
+
 <p style="text-align:center;">
     <input type="submit" name="submit" value="<?php echo $submit_text; ?>">
     <input type="reset"  name="reset"  value="<?php echo __('Reset');?>">
@@ -354,5 +433,20 @@ $(function() {
     };
     $('[name=sequence_id]').on('change', update_example);
     $('[name=number_format]').on('keyup', update_example);
+});
+$('table#topic-forms').sortable({
+  items: 'tbody',
+  handle: 'td.handle',
+  tolerance: 'pointer',
+  forcePlaceholderSize: true,
+  helper: function(e, ui) {
+    ui.children().each(function() {
+      $(this).children().each(function() {
+        $(this).width($(this).width());
+      });
+    });
+    ui=ui.clone().css({'background-color':'white', 'opacity':0.8});
+    return ui;
+  }
 });
 </script>

--- a/include/staff/page.inc.php
+++ b/include/staff/page.inc.php
@@ -116,10 +116,11 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
                     <li><a href="#notes"><?php echo __('Internal Notes'); ?></a></li>
                 </ul>
     <div class="tab_content active" id="content">
+<table class="full-width"><tbody><tr><td style="vertical-align:top">
 <?php
 $langs = Internationalization::getConfiguredSystemLanguages();
 if ($page && count($langs) > 1) { ?>
-    <ul class="vertical left tabs">
+    <ul class="vertical tabs" id="translations">
         <li class="empty"><i class="icon-globe" title="This content is translatable"></i></li>
 <?php foreach ($langs as $tag=>$nfo) { ?>
     <li class="<?php if ($tag == $cfg->getPrimaryLanguage()) echo "active";
@@ -131,15 +132,18 @@ if ($page && count($langs) > 1) { ?>
     </ul>
 <?php
 } ?>
-    <div id="msg_info" style="margin:0 55px">
+</td>
+<td id="translations_container" style="padding-left: 10px">
+    <div id="msg_info">
     <em><i class="icon-info-sign"></i> <?php
         echo __(
             'Ticket variables are only supported in thank-you pages.'
-    ); ?></em></div>
+        ); ?></em>
+    </div>
 
-        <div id="translation-<?php echo $cfg->getPrimaryLanguage(); ?>" class="tab_content" style="margin:0 45px"
+        <div id="translation-<?php echo $cfg->getPrimaryLanguage(); ?>" class="tab_content"
             lang="<?php echo $cfg->getPrimaryLanguage(); ?>">
-        <textarea name="body" cols="21" rows="12" style="width:98%;" class="richtext draft"
+        <textarea name="body" cols="21" rows="12" style="width:100%" class="richtext draft"
 <?php
     list($draft, $attrs) = Draft::getDraftAndDataAttrs('page', $info['id'], $info['body']);
     echo $attrs; ?>><?php echo $draft ?: $info['body']; ?></textarea>
@@ -150,17 +154,18 @@ if ($page && count($langs) > 1) { ?>
         if ($tag == $cfg->getPrimaryLanguage())
             continue; ?>
         <div id="translation-<?php echo $tag; ?>" class="tab_content"
-            style="display:none;margin:0 45px" lang="<?php echo $tag; ?>">
+            style="display:none;" lang="<?php echo $tag; ?>">
         <textarea name="trans[<?php echo $tag; ?>][body]" cols="21" rows="12"
-            style="width:98%;" class="richtext draft"
+            style="width:100%" class="richtext draft"
 <?php
     list($draft, $attrs) = Draft::getDraftAndDataAttrs('page', $info['id'].'.'.$tag, $info['trans'][$tag]);
     echo $attrs; ?>><?php echo $draft ?: $info['trans'][$tag]; ?></textarea>
         </div>
 <?php }
 } ?>
+</td></tr></tbody></table>
 
-        <div class="error" style="margin: 5px 55px"><?php echo $errors['body']; ?></div>
+        <div class="error" style="margin: 5px 0"><?php echo $errors['body']; ?></div>
         <div class="clear"></div>
     </div>
     <div class="tab_content" style="display:none" id="notes">

--- a/include/staff/templates/dynamic-form.tmpl.php
+++ b/include/staff/templates/dynamic-form.tmpl.php
@@ -38,6 +38,8 @@ if (isset($options['entry']) && $options['mode'] == 'edit') { ?>
     }
     foreach ($form->getFields() as $field) {
         try {
+            if (!$field->isEnabled())
+                continue;
             if ($options['mode'] == 'edit' && !$field->isEditableToStaff())
                 continue;
         }

--- a/include/staff/ticket-open.inc.php
+++ b/include/staff/ticket-open.inc.php
@@ -9,12 +9,14 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
 if (!$info['topicId'])
     $info['topicId'] = $cfg->getDefaultTopicId();
 
-$form = null;
+$forms = array();
 if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
-    $form = $topic->getForm();
-    if ($_POST && $form) {
-        $form = $form->instanciate();
-        $form->isValid();
+    foreach ($topic->getForms() as $F) {
+        if ($_POST) {
+            $F = $F->instanciate();
+            $F->isValidForClient();
+        }
+        $forms[] = $F;
     }
 }
 
@@ -156,9 +158,9 @@ if ($_POST)
                                 $id, ($info['topicId']==$id)?'selected="selected"':'',
                                 $selected, $name);
                         }
-                        if (count($topics) == 1 && !$form) {
+                        if (count($topics) == 1 && !$forms) {
                             if (($T = Topic::lookup($id)))
-                                $form =  $T->getForm();
+                                $forms =  $T->getForms();
                         }
                     }
                     ?>
@@ -260,16 +262,10 @@ if ($_POST)
         </tbody>
         <tbody id="dynamic-form">
         <?php
-            if ($form) {
+            foreach ($forms as $form) {
                 print $form->getForm()->getMedia();
                 include(STAFFINC_DIR .  'templates/dynamic-form.tmpl.php');
             }
-        ?>
-        </tbody>
-        <tbody> <?php
-        $tform = TicketForm::getInstance()->getForm($_POST);
-        if ($_POST) $tform->isValid();
-        $tform->render(true);
         ?>
         </tbody>
         <tbody>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -466,7 +466,7 @@ $tcount+= $ticket->getNumNotes();
             $msgId = $entry['id'];
        }
     } else {
-        echo '<p>'.__('Error fetching ticket thread - get technical help.').'</p>';
+        echo '<p><em>'.__('No entries have been posted to this ticket.').'</em></p>';
     }?>
 <div class="clear" style="padding-bottom:10px;"></div>
 <?php if($errors['err']) { ?>

--- a/include/upgrader/streams/core/5cd0a25a-00000000.cleanup.sql
+++ b/include/upgrader/streams/core/5cd0a25a-00000000.cleanup.sql
@@ -1,0 +1,8 @@
+/**
+ * @signature 0e47d678f50874fa0d33e1e3759f657e
+ * @version v1.9.6
+ * @title Make fields disable-able per help topic
+ */
+
+ALTER TABLE `%TABLE_PREFIX%help_topic`
+    DROP `form_id` int(10) unsigned NOT NULL default '0';

--- a/include/upgrader/streams/core/5cd0a25a-00000000.patch.sql
+++ b/include/upgrader/streams/core/5cd0a25a-00000000.patch.sql
@@ -1,0 +1,45 @@
+/**
+ * @signature 0e47d678f50874fa0d33e1e3759f657e
+ * @version v1.9.6
+ * @title Make fields disable-able per help topic
+ */
+
+ALTER TABLE `%TABLE_PREFIX%form`
+    ADD `pid` int(10) unsigned DEFAULT NULL AFTER `id`,
+    ADD `name` varchar(64) NOT NULL DEFAULT '' AFTER `instructions`;
+
+ALTER TABLE `%TABLE_PREFIX%form_entry`
+    ADD `extra` text AFTER `sort`;
+
+CREATE TABLE `%TABLE_PREFIX%help_topic_form` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `topic_id` int(11) unsigned NOT NULL default 0,
+  `form_id` int(10) unsigned NOT NULL default 0,
+  `sort` int(10) unsigned NOT NULL default 1,
+  `extra` text,
+  PRIMARY KEY  (`topic_id`, `form_id`)
+) DEFAULT CHARSET=utf8;
+
+insert into `%TABLE_PREFIX%help_topic_form`
+    (`topic_id`, `form_id`, `sort`)
+    select A1.topic_id, case
+        when A2.form_id = 4294967295 then A3.form_id
+        when A1.form_id = 4294967295 then A2.form_id
+        else A1.form_id end as form_id, 1 as `sort`
+    from `%TABLE_PREFIX%help_topic` A1
+    left join `%TABLE_PREFIX%help_topic` A2 on (A2.topic_pid = A1.topic_id)
+    left join `%TABLE_PREFIX%help_topic` A3 on (A3.topic_pid = A2.topic_id)
+    having `form_id` > 0
+    union
+    select A2.topic_id, id as `form_id`, 2 as `sort`
+    from `%TABLE_PREFIX%form` A1
+    join `%TABLE_PREFIX%help_topic` A2
+    where A1.`type` = 'T';
+
+ALTER TABLE `%TABLE_PREFIX%help_topic`
+    DROP `form_id` int(10) unsigned NOT NULL default '0';
+
+-- Finished with patch
+UPDATE `%TABLE_PREFIX%config`
+    SET `value` = '0e47d678f50874fa0d33e1e3759f657e'
+    WHERE `key` = 'schema_signature' AND `namespace` = 'core';

--- a/scp/ajax.php
+++ b/scp/ajax.php
@@ -57,7 +57,8 @@ $dispatcher = patterns('',
         url_post('^field-config/(?P<id>\d+)$', 'saveFieldConfiguration'),
         url_delete('^answer/(?P<entry>\d+)/(?P<field>\d+)$', 'deleteAnswer'),
         url_post('^upload/(\d+)?$', 'upload'),
-        url_post('^upload/(\w+)?$', 'attach')
+        url_post('^upload/(\w+)?$', 'attach'),
+        url_get('^(?P<id>\d+)/fields/view$', 'getAllFields')
     )),
     url('^/list/', patterns('ajax.forms.php:DynamicFormsAjaxAPI',
         url_get('^(?P<list>\w+)/item/(?P<id>\d+)/properties$', 'getListItemProperties'),

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -2133,3 +2133,7 @@ td.indented {
    position: relative;
    top: -1px;
 }
+
+#topic-forms tbody + tbody td.handle {
+  padding-top: 15px;
+}

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -632,10 +632,16 @@ table.fixed {
     border-collapse: collapse;
     width: 100%;
 }
-table.fixed td {
+table.fixed > thead > tr > th,
+table.fixed > thead > tr > td,
+table.fixed > tbody > tr > td,
+table.fixed > tr > td {
     width: 180px;
 }
-table.fixed td + td {
+table.fixed > thead > tr > th + th,
+table.fixed > thead > tr > td + td,
+table.fixed > tbody > tr > td + td,
+table.fixed > tr > td + td {
     width: auto;
 }
 

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -51,6 +51,10 @@ div#header a {
     clear:both;
 }
 
+.big {
+    font-size: 110%;
+}
+
 .faded {
     color:#666;
 }
@@ -587,6 +591,27 @@ a.print {
     border:1px solid #aaa;
     background:#fff;
     padding:2px;
+}
+
+.table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top:3px;
+}
+
+.table tr.header td,
+.table th {
+    font-weight: bold;
+    text-align: left;
+    height: 24px;
+    background: #f0f0f0;
+}
+
+.table tr {
+    border-bottom:1px dotted #ddd;
+}
+.table td:not(:empty) {
+    height: 24px;
 }
 
 .form_table {

--- a/scp/css/translatable.css
+++ b/scp/css/translatable.css
@@ -100,13 +100,14 @@ div.translatable {
   box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
   display: inline-block;
   white-space: nowrap;
-  border-top-left-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
   border-right: none;
-  padding: 0 5px 2px;
+  padding: 1px 5px 1px;
   margin-left: 2px;
   width: auto;
   background-color: white;
+  line-height: 16px;
 }
 div.translatable.textarea {
   border: 1px solid #bbb;

--- a/setup/inc/streams/core/install-mysql.sql
+++ b/setup/inc/streams/core/install-mysql.sql
@@ -115,10 +115,12 @@ INSERT INTO `%TABLE_PREFIX%config` (`namespace`, `key`, `value`) VALUES
 DROP TABLE IF EXISTS `%TABLE_PREFIX%form`;
 CREATE TABLE `%TABLE_PREFIX%form` (
     `id` int(11) unsigned NOT NULL auto_increment,
+    `pid` int(10) unsigned DEFAULT NULL,
     `type` varchar(8) NOT NULL DEFAULT 'G',
     `deletable` tinyint(1) NOT NULL DEFAULT 1,
     `title` varchar(255) NOT NULL,
     `instructions` varchar(512),
+    `name` varchar(64) NOT NULL DEFAULT '',
     `notes` text,
     `created` datetime NOT NULL,
     `updated` datetime NOT NULL,
@@ -151,6 +153,7 @@ CREATE TABLE `%TABLE_PREFIX%form_entry` (
     `object_id` int(11) unsigned,
     `object_type` char(1) NOT NULL DEFAULT 'T',
     `sort` int(11) unsigned NOT NULL DEFAULT 1,
+    `extra` text,
     `created` datetime NOT NULL,
     `updated` datetime NOT NULL,
     PRIMARY KEY (`id`),
@@ -443,7 +446,6 @@ CREATE TABLE `%TABLE_PREFIX%help_topic` (
   `team_id` int(10) unsigned NOT NULL default '0',
   `sla_id` int(10) unsigned NOT NULL default '0',
   `page_id` int(10) unsigned NOT NULL default '0',
-  `form_id` int(10) unsigned NOT NULL default '0',
   `sequence_id` int(10) unsigned NOT NULL DEFAULT '0',
   `sort` int(10) unsigned NOT NULL default '0',
   `topic` varchar(32) NOT NULL default '',
@@ -459,6 +461,16 @@ CREATE TABLE `%TABLE_PREFIX%help_topic` (
   KEY `staff_id` (`staff_id`,`team_id`),
   KEY `sla_id` (`sla_id`),
   KEY `page_id` (`page_id`)
+) DEFAULT CHARSET=utf8;
+
+DROP TABLE IF EXISTS `%TABLE_PREFIX%help_topic_form`;
+CREATE TABLE `%TABLE_PREFIX%help_topic_form` (
+  `id` int(11) unsigned NOT NULL auto_increment,
+  `topic_id` int(11) unsigned NOT NULL default 0,
+  `form_id` int(10) unsigned NOT NULL default 0,
+  `sort` int(10) unsigned NOT NULL default 1,
+  `extra` text,
+  PRIMARY KEY  (`topic_id`, `form_id`)
 ) DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS `%TABLE_PREFIX%organization`;


### PR DESCRIPTION
Help topics can now specify one or more additional forms to be included on the help topic and can also specify the sort order of those forms. Furthermore, individual fields can be disabled per help topic, so that unnecessary fields can be omitted when necessary, per help topic.

The disabled flag is recorded along side the field data so that the field will not be accidentally added to the form later automatically. There is no interface in this commit to enable a field which was disabled by the help topic when ticket was created.

### Outstanding

  * [x] Convert `%form.instructions` to HTML, including a migration task
  * [ ] Collapse #1349

### Screenshots

##### Help topic management is organized into tabs
![screen shot 2014-12-12 at 4 42 50 pm](https://cloud.githubusercontent.com/assets/672074/5420705/468d7d28-821e-11e4-9ac1-ccd9ac2cfd3b.png)

##### One or more forms can be added to the ticket when using this help topic, individual fields can be disabled
![screen shot 2014-12-12 at 4 42 57 pm](https://cloud.githubusercontent.com/assets/672074/5420712/54df8196-821e-11e4-92a7-1dcb530bfb8f.png)

##### Form design order is preserved on the new ticket page
![screen shot 2014-12-12 at 4 44 13 pm](https://cloud.githubusercontent.com/assets/672074/5420725/784ddaa6-821e-11e4-8e5a-8ded8b9389cf.png)