### PR TITLE
file: Add import/export support

### DIFF
--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -206,9 +206,9 @@ class VerySimpleModel {
         foreach ($this->dirty as $field=>$old) {
             if ($this->__new__ or !in_array($field, $pk)) {
                 if (@get_class($this->get($field)) == 'SqlFunction')
-                    $fields[] = $field.' = '.$this->get($field)->toSql();
+                    $fields[] = "`$field` = ".$this->get($field)->toSql();
                 else
-                    $fields[] = $field.' = '.db_input($this->get($field));
+                    $fields[] = "`$field` = ".db_input($this->get($field));
             }
         }
         $sql .= ' SET '.implode(', ', $fields);

--- a/setup/cli/modules/class.module.php
+++ b/setup/cli/modules/class.module.php
@@ -92,11 +92,10 @@ class Option {
 class OutputStream {
     var $stream;
 
-    function OutputStream() {
-        call_user_func_array(array($this, '__construct'), func_get_args());
-    }
     function __construct($stream) {
-        $this->stream = fopen($stream, 'w');
+        if (!($this->stream = fopen($stream, 'w')))
+            throw new Exception(sprintf('%s: Cannot open for writing',
+                $stream));
     }
 
     function write($what) {

--- a/setup/cli/modules/file.php
+++ b/setup/cli/modules/file.php
@@ -319,6 +319,7 @@ class FileManager extends Module {
                 // Write file contents to the backend
                 $md5 = hash_init('md5');
                 $sha1 = hash_init('sha1');
+                $written = 0;
 
                 // Handle exceptions by dropping imported file contents and
                 // then returning the error to the error output stream.
@@ -348,8 +349,11 @@ class FileManager extends Module {
                         hash_update($md5, $contents);
                         hash_update($sha1, $contents);
                         $dlen -= strlen($contents);
+                        $written += strlen($contents);
                     }
-                    if (!$bk->flush())
+                    // Some backends cannot handle flush() without a
+                    // corresponding write() call.
+                    if ($written && !$bk->flush())
                         throw new Exception(
                             'Unable to commit file contents to backend');
 


### PR DESCRIPTION
This patch adds an export+import method to the file command line module. The file export is agnostic of the file storage backend. It writes the files with the %file record data to standard-out or to the file given by the -f option. The file is a considered a stream and can quietly be compressed and can be read back in as a stream (no seeking is performed in the import process).

Export all files from your helpdesk (as a backup)
```
php setup/cli/manage.php file export > osticket-files.dat
```

Import the backup some time later
```
php setup/cli/manage.php file import < osticket-files.dat
```