### PR TITLE
Session never expires

### DIFF
--- a/include/class.ostsession.php
+++ b/include/class.ostsession.php
@@ -69,6 +69,23 @@ class osTicketSession {
         $this->destroy($oldId);
     }
 
+    static function destroyCookie() {
+        setcookie(session_name(), 'deleted', 1,
+            ini_get('session.cookie_path'),
+            ini_get('session.cookie_domain'),
+            ini_get('session.cookie_secure'),
+            ini_get('session.cookie_httponly'));
+    }
+
+    static function renewCookie($baseTime=false, $window=false) {
+        setcookie(session_name(), session_id(),
+            ($baseTime ?: time()) + ($window ?: SESSION_TTL),
+            ini_get('session.cookie_path'),
+            ini_get('session.cookie_domain'),
+            ini_get('session.cookie_secure'),
+            ini_get('session.cookie_httponly'));
+    }
+
     function open($save_path, $session_name){
         return (true);
     }

--- a/include/class.usersession.php
+++ b/include/class.usersession.php
@@ -133,6 +133,8 @@ class ClientSession extends EndUser {
     }
 
     function refreshSession($force=false){
+        global $cfg;
+
         $time = $this->session->getLastUpdate($this->token);
         // Deadband session token updates to once / 30-seconds
         if (!$force && time() - $time < 30)
@@ -140,6 +142,13 @@ class ClientSession extends EndUser {
 
         $this->token = $this->getSessionToken();
         //TODO: separate expire time from hash??
+
+        setcookie(session_name(), session_id(),
+            ($time ?: time()) + ($cfg->getClientTimeout() ?: 604800),
+            ini_get('session.cookie_path'),
+            ini_get('session.cookie_domain'),
+            ini_get('session.cookie_secure'),
+            ini_get('session.cookie_httponly'));
     }
 
     function getSession() {
@@ -177,12 +186,21 @@ class StaffSession extends Staff {
     }
 
     function refreshSession($force=false){
+        global $cfg;
+
         $time = $this->session->getLastUpdate($this->token);
         // Deadband session token updates to once / 30-seconds
         if (!$force && time() - $time < 30)
             return;
 
         $this->token=$this->getSessionToken();
+
+        setcookie(session_name(), session_id(),
+            ($time ?: time()) + ($cfg->getStaffTimeout() ?: 604800),
+            ini_get('session.cookie_path'),
+            ini_get('session.cookie_domain'),
+            ini_get('session.cookie_secure'),
+            ini_get('session.cookie_httponly'));
     }
 
     function getSession() {

--- a/include/class.usersession.php
+++ b/include/class.usersession.php
@@ -143,12 +143,7 @@ class ClientSession extends EndUser {
         $this->token = $this->getSessionToken();
         //TODO: separate expire time from hash??
 
-        setcookie(session_name(), session_id(),
-            ($time ?: time()) + ($cfg->getClientTimeout() ?: 604800),
-            ini_get('session.cookie_path'),
-            ini_get('session.cookie_domain'),
-            ini_get('session.cookie_secure'),
-            ini_get('session.cookie_httponly'));
+        osTicketSession::renewCookie($time, $cfg->getClientSessionTimeout());
     }
 
     function getSession() {
@@ -195,12 +190,7 @@ class StaffSession extends Staff {
 
         $this->token=$this->getSessionToken();
 
-        setcookie(session_name(), session_id(),
-            ($time ?: time()) + ($cfg->getStaffTimeout() ?: 604800),
-            ini_get('session.cookie_path'),
-            ini_get('session.cookie_domain'),
-            ini_get('session.cookie_secure'),
-            ini_get('session.cookie_httponly'));
+        osTicketSession::renewCookie($time, $cfg->getStaffSessionTimeout());
     }
 
     function getSession() {

--- a/logout.php
+++ b/logout.php
@@ -19,11 +19,7 @@ require('client.inc.php');
 if ($thisclient && $_GET['auth'] && $ost->validateLinkToken($_GET['auth']))
    $thisclient->logOut();
 
-setcookie(session_name(), 'deleted', 1,
-    ini_get('session.cookie_path'),
-    ini_get('session.cookie_domain'),
-    ini_get('session.cookie_secure'),
-    ini_get('session.cookie_httponly'));
+osTicketSession::destroyCookie();
 
 Http::redirect('index.php');
 ?>

--- a/logout.php
+++ b/logout.php
@@ -19,6 +19,11 @@ require('client.inc.php');
 if ($thisclient && $_GET['auth'] && $ost->validateLinkToken($_GET['auth']))
    $thisclient->logOut();
 
+setcookie(session_name(), 'deleted', 1,
+    ini_get('session.cookie_path'),
+    ini_get('session.cookie_domain'),
+    ini_get('session.cookie_secure'),
+    ini_get('session.cookie_httponly'));
 
 Http::redirect('index.php');
 ?>

--- a/scp/logout.php
+++ b/scp/logout.php
@@ -31,6 +31,12 @@ TicketLock::removeStaffLocks($thisstaff->getId());
 session_unset();
 session_destroy();
 
+setcookie(session_name(), 'deleted', 1,
+    ini_get('session.cookie_path'),
+    ini_get('session.cookie_domain'),
+    ini_get('session.cookie_secure'),
+    ini_get('session.cookie_httponly'));
+
 @header('Location: login.php');
 require('login.php');
 ?>

--- a/scp/logout.php
+++ b/scp/logout.php
@@ -31,11 +31,7 @@ TicketLock::removeStaffLocks($thisstaff->getId());
 session_unset();
 session_destroy();
 
-setcookie(session_name(), 'deleted', 1,
-    ini_get('session.cookie_path'),
-    ini_get('session.cookie_domain'),
-    ini_get('session.cookie_secure'),
-    ini_get('session.cookie_httponly'));
+osTicketSession::destroyCookie();
 
 @header('Location: login.php');
 require('login.php');


### PR DESCRIPTION
This patch sends updated session cookies to the browser when the session is refreshed on the server. This allows the session cookie to expire on the browser at the same time the session timeout occurs at the server. In the event the session timeout is configured in osTicket not to expire, the cookie will expire after seven days on the client browser, and will expire in PHP when it is garbage collected sometime after 86400 seconds after the time last refresh time.

Using this method, the session will never expire if the session timeout in osTicket is configured to 0, and the session is refreshed at least daily.

This patch also forces the client to delete the cookie at logout.