### PR TITLE
thread: Fix a couple issues with email message-ids

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -125,28 +125,24 @@ class Mailer {
      *   -or- Original From email address
      */
     function getMessageId($recipient, $options=array(), $version='A') {
-        $tag = '';
         $rand = Misc::randCode(9,
             // RFC822 specifies the LHS of the addr-spec can have any char
             // except the specials — ()<>@,;:\".[], dash is reserved as the
             // section separator, and + is reserved for historical reasons
             'abcdefghiklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_=');
-        $sig = $this->getEmail()?$this->getEmail()->getEmail():'@osTicketMailer';
-        if ($recipient instanceof EmailContact) {
-            // Create a tag for the outbound email
-            $tag = pack('VVa',
-                $recipient->getId(),
-                (isset($options['thread']) && $options['thread'] instanceof ThreadEntry)
-                    ? $options['thread']->getId() : 0,
-                ($recipient instanceof Staff ? 'S'
-                    : ($recipient instanceof TicketOwner ? 'U'
-                    : ($recipient instanceof Collaborator ? 'C'
-                    : '?')))
-            );
-            $tag = str_replace('=','',base64_encode($tag));
-            // Sign the tag with the system secret salt
-            $sig = '@' . substr(hash_hmac('sha1', $tag.$rand, SECRET_SALT), -10);
-        }
+        // Create a tag for the outbound email
+        $tag = pack('VVa',
+            ($recipient instanceof EmailContact) ? $recipient->getUserId() : 0,
+            (isset($options['thread']) && $options['thread'] instanceof ThreadEntry)
+                ? $options['thread']->getId() : 0,
+            ($recipient instanceof Staff ? 'S'
+                : ($recipient instanceof TicketOwner ? 'U'
+                : ($recipient instanceof Collaborator ? 'C'
+                : '?')))
+        );
+        $tag = str_replace('=','',base64_encode($tag));
+        // Sign the tag with the system secret salt
+        $sig = '@' . substr(hash_hmac('sha1', $tag.$rand, SECRET_SALT), -10);
         return sprintf('<A%s-%s-%s-%s>',
             static::getSystemMessageIdCode(),
             $rand, $tag, $sig);
@@ -210,7 +206,7 @@ class Mailer {
                     $rv += unpack('Vuid/VthreadId/auserClass', $tag);
                     // Attempt to make the user-id more specific
                     $classes = array(
-                        'S' => 'staffId', 'U' => 'userId'
+                        'S' => 'staffId', 'U' => 'userId', 'C' => 'userId',
                     );
                     if (isset($classes[$rv['userClass']]))
                         $rv[$classes[$rv['userClass']]] = $rv['uid'];
@@ -304,6 +300,7 @@ class Mailer {
         }
 
         // Make the best effort to add In-Reply-To and References headers
+        $reply_tag = $mid_token = '';
         if (isset($options['thread'])
             && $options['thread'] instanceof ThreadEntry
         ) {
@@ -321,6 +318,12 @@ class Mailer {
                     'References' => $parent->getEmailReferences(),
                 );
             }
+
+            // Configure the reply tag and embedded message id token
+            $mid_token = $options['thread']->asMessageId($to);
+            if ($cfg && $cfg->stripQuotedReply()
+                    && (!isset($options['reply-tag']) || $options['reply-tag']))
+                $reply_tag = $cfg->getReplySeparator() . '<br/><br/>';
         }
 
         // Use Mail_mime default initially
@@ -348,15 +351,11 @@ class Mailer {
         // then assume that it needs html processing to create a valid text
         // body
         $isHtml = true;
-        $mid_token = (isset($options['thread']))
-            ? $options['thread']->asMessageId($to) : '';
         if (!(isset($options['text']) && $options['text'])) {
-            $tag = '';
-            if ($cfg && $cfg->stripQuotedReply()
-                    && (!isset($options['reply-tag']) || $options['reply-tag']))
-                $tag = $cfg->getReplySeparator() . '<br/><br/>';
-            $message = "<div style=\"display:none\"
-                data-mid=\"$mid_token\">$tag</div>$message";
+            if ($reply_tag || $mid_token) {
+                $message = "<div style=\"display:none\"
+                    data-mid=\"$mid_token\">$reply_tag</div>$message";
+            }
             $txtbody = rtrim(Format::html2text($message, 90, false))
                 . ($mid_token ? "\nRef-Mid: $mid_token\n" : '');
             $mime->setTXTBody($txtbody);

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -176,6 +176,9 @@ implements EmailContact {
     function getId() {
         return $this->id;
     }
+    function getUserId() {
+        return $this->getId();
+    }
 
     function getEmail() {
         return $this->ht['email'];


### PR DESCRIPTION
  * Fix matching of collaborators on return emails. Previously the collaborator ID was used instead of the related user ID. Also, the 'C' user class (collaborator) was not handled in ::decodeMessageId()
  * Only send a reply separator for email related to a thread
  * Always generate a tag for the email message id. This will allow reply from the help desk administrator for the new ticket alert