### PR TITLE
priority: Fix empty export and default selection

### DIFF
--- a/include/class.export.php
+++ b/include/class.export.php
@@ -53,10 +53,6 @@ class Export {
 
             $name = $f->get('name') ? $f->get('name') : 'field_'.$f->get('id');
             $key = '__field_'.$f->get('id');
-            // Fetch ID values for ID-based data
-            if ($f->hasIdValue()) {
-                $name .= '_id';
-            }
             $cdata[$key] = $f->get('label');
             $fields[$key] = $f;
             $select[] = "cdata.`$name` AS __field_".$f->get('id');

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1205,7 +1205,10 @@ class PriorityField extends ChoiceField {
             reset($id);
             $id = key($id);
         }
-        return Priority::lookup($id);
+        elseif ($id === false)
+            $id = $value;
+        if ($id)
+            return Priority::lookup($id);
     }
 
     function to_database($prio) {


### PR DESCRIPTION
If the ticket details form has an extra field of type "Priority Level" (beyond the one built in), exports of tickets to CSV will be empty.

This patch addresses the issue in the exporter which uses an older version of the custom data materialized view (cdata table), which created separate columns for selection and ID values. The current cdata system only creates a single column and stores the ID value. 

It also addresses an issue where the ID column was passed to the `PriorityField::to_php()` as the first argument, which prevented correct values in the export.

It also allows for multiple priority fields to specify differing defaults, and it also allows for a selection of 'System Default' in the config, which renders as 'Default' when rendered.