### PR TITLE
[FIX] Missing icon before "Add New Filter"

### DIFF
--- a/include/staff/filters.inc.php
+++ b/include/staff/filters.inc.php
@@ -49,7 +49,7 @@ else
  <h2><?php echo __('Ticket Filters');?></h2>
 </div>
 <div class="pull-right flush-right" style="padding-top:5px;padding-right:5px;">
- <b><a href="filters.php?a=add" class="Icon newEmailFilter"><?php echo __('Add New Filter');?></a></b></div>
+ <b><a href="filters.php?a=add" class="Icon newTicketFilter"><?php echo __('Add New Filter');?></a></b></div>
 <div class="clear"></div>
 <form action="filters.php" method="POST" name="filters">
  <?php csrf_token(); ?>


### PR DESCRIPTION
Fixes the missing icon before "Add new filter" in scp at the filters.php page.

Guess it was some copy and paste thing ;)