### PR TITLE
Allow characters in random ticket number.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ setup/cli/modules/importer
 .vagrant
 ._.DS_Store
 Vagrantfile
+nbproject/*
 
 # Staging directory used for packaging script
 stage

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -847,6 +847,7 @@ class Ticket {
                 $sql.=', closed=NOW(), duedate=NULL ';
                 if ($thisstaff && $set_closing_agent)
                     $sql.=', staff_id='.db_input($thisstaff->getId());
+                $this->clearOverdue();
 
                 $ecb = function($t) {
                     $t->reload();

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -22,6 +22,8 @@ number_format:
         Topics</span> can define custom number formats.
         <br/><br/>
         For example, for six-digit numbers, use <code>######</code>.
+        <br/>
+        For example, for six-digit numbers followed by a letter, use <code>######@</code>.
 
 sequence_id:
     title: Ticket Number Sequence


### PR DESCRIPTION
Allow random numbers to include characters when specified using the @ symbol.

I.e. US-####-@@

![c9c1170b63b7fee9f53ad6113cab6dc1](https://cloud.githubusercontent.com/assets/1240362/6219391/c2131dd2-b620-11e4-90f5-c21c1f5b8ee8.png)
