### PR TITLE
Dev switch to disable autocron.

### DIFF
--- a/include/ost-sampleconfig.php
+++ b/include/ost-sampleconfig.php
@@ -47,6 +47,9 @@ define('DBPASS','%CONFIG-DBPASS');
 # Table prefix
 define('TABLE_PREFIX','%CONFIG-PREFIX');
 
+#Dev switch for disabling autocron
+define('DEV', CFG::DEV);
+
 #
 # SSL Options
 # ---------------------------------------------------

--- a/scp/autocron.php
+++ b/scp/autocron.php
@@ -49,7 +49,7 @@ Cron::TicketMonitor(); //Age tickets: We're going to age tickets regardless of c
 if (mt_rand(1, 9) == 4)
     Cron::CleanOrphanedFiles();
 
-if($cfg && $cfg->isAutoCronEnabled()) { //ONLY fetch tickets if autocron is enabled!
+if($cfg && $cfg->isAutoCronEnabled() && !DEV) { //ONLY fetch tickets if autocron is enabled!
     Cron::MailFetcher();  //Fetch mail.
     $ost->logDebug(_S('Auto Cron'), sprintf(_S('Mail fetcher cron call [%s]'), $caller));
 }


### PR DESCRIPTION
This is necessary if using copy of live data on development server.

This prevents unwanted email fetching on developement server, when having live config on database.