### PR TITLE
Add %{message} as an available variable for assignment emails.

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1242,10 +1242,15 @@ class Ticket {
         if ($recipients
                 && ($msg=$tpl->getAssignedAlertMsgTemplate())) {
 
+            //Add %{message} as an available template variable.
+            //Shows the first message from the thread.
+            $message = array_shift($this->getMessages());
+
             $msg = $this->replaceVars($msg->asArray(),
                         array('comments' => $comments,
                               'assignee' => $assignee,
-                              'assigner' => $assigner
+                              'assigner' => $assigner,
+                              'message' => isset($message['body']) ? $message['body'] : '',
                               ));
 
             //Send the alerts.


### PR DESCRIPTION
This change allows the %{message} variable to be used in the Ticket Assignment Alert email template. It just uses the first message from the ticket thread.