### PR TITLE
forms: Add Textbox Selection Widget

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -2274,6 +2274,30 @@ class TextboxWidget extends Widget {
     }
 }
 
+
+class TextboxSelectionWidget extends TextboxWidget {
+    //TODO: Support multi-input e.g comma separated inputs
+    function render($options=array()) {
+
+        if ($this->value && is_array($this->value))
+            $this->value = current($this->value);
+
+        parent::render($options);
+    }
+
+    function getValue() {
+
+        $value = parent::getValue();
+        if (($i=$this->field->getList()->getItem((string) $value)))
+            $value = array($i->getId() => $i->getValue());
+        elseif (($choices=$this->field->getChoices())
+                && ($k=array_search($value, $choices)))
+            $value = array($k => $choices[$k]);
+
+        return $value;
+    }
+}
+
 class PasswordWidget extends TextboxWidget {
     static $input_type = 'password';
 


### PR DESCRIPTION
Add a text box widget to selection field. It functions like typeahead and drop down widgets with the exception that the user doesn't get the hint. This is useful when an internal list needs to be used to validate user's input e.g serial numbers.

![screen shot 2015-02-25 at 1 56 23 am](https://cloud.githubusercontent.com/assets/31067/6366906/e7ff8da6-bc91-11e4-8d15-e85caaa3104e.png)
