### PR TITLE
filedrop: Support Firefox down to v6

### DIFF
--- a/js/filedrop.field.js
+++ b/js/filedrop.field.js
@@ -330,7 +330,8 @@
       globalProgressUpdated: empty,
       speedUpdated: empty
       },
-      errors = ["BrowserNotSupported", "TooManyFiles", "FileTooLarge", "FileTypeNotAllowed", "NotFound", "NotReadable", "AbortError", "ReadError", "FileExtensionNotAllowed"];
+      errors = ["BrowserNotSupported", "TooManyFiles", "FileTooLarge", "FileTypeNotAllowed", "NotFound", "NotReadable", "AbortError", "ReadError", "FileExtensionNotAllowed"],
+      Blob = window.WebKitBlob || window.MozBlob || window.Blob;
 
   $.fn.filedrop = function(options) {
     var opts = $.extend({}, default_opts, options),
@@ -380,8 +381,7 @@
       var dashdash = '--',
           crlf = '\r\n',
           builder = [],
-          paramname = opts.paramname,
-          Blob = window.WebKitBlob || window.Blob;
+          paramname = opts.paramname;
 
       if (opts.data) {
         var params = $.param(opts.data).replace(/\+/g, '%20').split(/&/);
@@ -474,6 +474,10 @@
       stop_loop = false;
 
       if (!files) {
+        opts.error(errors[0]);
+        return false;
+      }
+      if (typeof Blob === "undefined") {
         opts.error(errors[0]);
         return false;
       }


### PR DESCRIPTION
Also, give a "Browser not supported" error for browsers which do not support the Blob constructor.

Maybe fixes #1746

References:
http://caniuse.com/#feat=blobbuilder