### PR TITLE
access: Allow empty staff banner. Show update errors

### DIFF
--- a/include/class.page.php
+++ b/include/class.page.php
@@ -229,7 +229,7 @@ class Page {
             ? $p : null;
     }
 
-    function save($id, $vars, &$errors) {
+    function save($id, $vars, &$errors, $allowempty=false) {
 
         //Cleanup.
         $vars['name']=Format::striptags(trim($vars['name']));
@@ -246,7 +246,7 @@ class Page {
         elseif(($pid=self::getIdByName($vars['name'])) && $pid!=$id)
             $errors['name'] = __('Name already exists');
 
-        if(!$vars['body'])
+        if(!$vars['body'] && !$allowempty)
             $errors['body'] = __('Page body is required');
 
         if($errors) return false;

--- a/include/staff/settings-access.inc.php
+++ b/include/staff/settings-access.inc.php
@@ -170,14 +170,19 @@ $manage_content = function($title, $content) use ($contents) {
     ?><tr><td colspan="2">
     <a href="#ajax.php/content/<?php echo $id; ?>/manage"
     onclick="javascript:
-        $.dialog($(this).attr('href').substr(1), 200);
-    return false;"><i class="icon-file-text pull-left icon-2x"
-        style="color:#bbb;"></i> <?php
+        $.dialog($(this).attr('href').substr(1), 201);
+    return false;" class="pull-left"><i class="icon-file-text icon-2x"
+        style="color:#bbb;"></i> </a>
+    <span style="display:inline-block;width:90%;padding-left:10px;line-height:1.2em">
+    <a href="#ajax.php/content/<?php echo $id; ?>/manage"
+    onclick="javascript:
+        $.dialog($(this).attr('href').substr(1), 201);
+    return false;"><?php
     echo Format::htmlchars($title); ?></a><br/>
-        <span class="faded" style="display:inline-block;width:90%"><?php
+    <span class="faded"><?php
         echo Format::display($notes); ?>
     <em>(<?php echo sprintf(__('Last Updated %s'), Format::db_datetime($upd));
-        ?>)</em></span></td></tr><?php
+        ?>)</em></span></span></td></tr><?php
 }; ?>
         <tr>
             <th colspan="2">

--- a/include/staff/templates/content-manage.tmpl.php
+++ b/include/staff/templates/content-manage.tmpl.php
@@ -1,12 +1,19 @@
 <h3><?php echo __('Manage Content'); ?> &mdash; <?php echo Format::htmlchars($content->getName()); ?></h3>
 <a class="close" href=""><i class="icon-remove-circle"></i></a>
 <hr/>
-<form method="post" action="#content/<?php echo $content->getId(); ?>">
+<?php if ($errors['err']) { ?>
+<div class="error-banner">
+    <?php echo $errors['err']; ?>
+</div>
+<?php } ?>
+<form method="post" action="#content/<?php echo $info['id']; ?>">
+    <div class="error"><?php echo $errors['name']; ?></div>
     <input type="text" style="width: 100%; font-size: 14pt" name="name" value="<?php
-        echo Format::htmlchars($content->getName()); ?>" />
+        echo Format::htmlchars($info['name']); ?>" />
     <div style="margin-top: 5px">
+    <div class="error"><?php echo $errors['body']; ?></div>
     <textarea class="richtext no-bar" name="body"><?php
-    echo Format::viewableImages($content->getBody());
+    echo Format::viewableImages($info['body']);
 ?></textarea>
     </div>
     <div id="msg_info" style="margin-top:7px"><?php


### PR DESCRIPTION
Allow the staff banner to be set to empty (which is the default).

Also display the update errors back on the dialog for failed updated.

Maybe fixes #1775