### PR TITLE
draft: Find the draft corresponding to your user id

### DIFF
--- a/include/ajax.draft.php
+++ b/include/ajax.draft.php
@@ -146,7 +146,6 @@ class DraftAjaxAPI extends AjaxController {
             Http::response(403, "Valid session required");
 
         $vars = array(
-            'staff_id' => ($thisclient) ? $thisclient->getId() : 1<<31,
             'namespace' => $namespace,
         );
 
@@ -238,7 +237,6 @@ class DraftAjaxAPI extends AjaxController {
             Http::response(403, "Valid session required");
 
         $draft = Draft::create(array(
-            'staff_id' => ($thisclient) ? $thisclient->getId() : 1<<31,
             'namespace' => $namespace,
         ));
         if (!$draft->save())
@@ -255,7 +253,6 @@ class DraftAjaxAPI extends AjaxController {
             Http::response(403, "Login required for draft creation");
 
         $vars = array(
-            'staff_id' => $thisstaff->getId(),
             'namespace' => $namespace,
         );
 
@@ -311,7 +308,6 @@ class DraftAjaxAPI extends AjaxController {
             Http::response(403, "Login required for image upload");
 
         $draft = Draft::create(array(
-            'staff_id' => $thisstaff->getId(),
             'namespace' => $namespace
         ));
         if (!$draft->save())

--- a/include/class.draft.php
+++ b/include/class.draft.php
@@ -36,10 +36,23 @@ class Draft extends VerySimpleModel {
     function getStaffId() { return $this->staff_id; }
     function getNamespace() { return $this->namespace; }
 
+    static protected function getCurrentUserId() {
+        global $thisstaff, $thisclient;
+        
+        $user = $thisstaff ?: $thisclient;
+        if ($user)
+            return $user->getId();
+
+        return 1 << 31;
+    }
+
     static function getDraftAndDataAttrs($namespace, $id=0, $original='') {
         $draft_body = null;
         $attrs = array(sprintf('data-draft-namespace="%s"', Format::htmlchars($namespace)));
-        $criteria = array('namespace'=>$namespace);
+        $criteria = array(
+            'namespace' => $namespace,
+            'staff_id' => self::getCurrentUserId(),
+        );
         if ($id) {
             $attrs[] = sprintf('data-draft-object-id="%s"', Format::htmlchars($id));
             $criteria['namespace'] .= '.' . $id;
@@ -129,6 +142,7 @@ class Draft extends VerySimpleModel {
         unset($vars['attachments']);
 
         $vars['created'] = SqlFunction::NOW();
+        $vars['staff_id'] = self::getCurrentUserId();
         $draft = parent::create($vars);
 
         // Cloned attachments ...

--- a/js/redactor-osticket.js
+++ b/js/redactor-osticket.js
@@ -32,7 +32,6 @@ RedactorPlugins.draft = function() {
             this.opts.clipboardUploadUrl =
             this.opts.imageUpload =
                 'ajax.php/draft/'+this.opts.draftId+'/attach';
-            this.autosave.enable();
         }
         else {
             // Just upload the file. A draft will be created automatically
@@ -41,6 +40,8 @@ RedactorPlugins.draft = function() {
             this.opts.imageUpload = this.opts.autoCreateUrl + '/attach';
             this.opts.imageUploadCallback = this.afterUpdateDraft;
         }
+        if (autosave_url)
+            this.autosave.enable();
 
         this.$draft_saved = $('<span>')
             .addClass("pull-right draft-saved")


### PR DESCRIPTION
Previously, any draft would be identified — even if it isn't owned by the current user. Then, when the draft would attempt to be updated, the update would be refused and the annoying draft saved popup would appear.