### PR TITLE
oops: Fix corruption of thread body posted by collabs

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -742,9 +742,10 @@ Class ThreadEntry {
         else {
             //XXX: Are we potentially leaking the email address to
             // collaborators?
-            $header = sprintf("Received From: %s\n\n", $mailinfo['email']);
+            $header = sprintf("Received From: %s <%s>\n\n", $mailinfo['name'],
+                $mailinfo['email']);
             if ($body instanceof HtmlThreadBody)
-                $header = nl2br($header);
+                $header = nl2br(Format::htmlchars($header));
             // Add the banner to the top of the message
             if ($body instanceof ThreadBody)
                 $body->prepend($header);

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -742,8 +742,14 @@ Class ThreadEntry {
         else {
             //XXX: Are we potentially leaking the email address to
             // collaborators?
-            $vars['message'] = sprintf("Received From: %s\n\n%s",
-                $mailinfo['email'], $body);
+            $header = sprintf("Received From: %s\n\n", $mailinfo['email']);
+            if ($body instanceof HtmlThreadBody)
+                $header = nl2br($header);
+            // Add the banner to the top of the message
+            if ($body instanceof ThreadBody)
+                $body->prepend($header);
+
+            $vars['message'] = $body;
             $vars['userId'] = 0; //Unknown user! //XXX: Assume ticket owner?
             return $ticket->postMessage($vars, 'Email');
         }
@@ -1383,6 +1389,14 @@ class ThreadBody /* extends SplString */ {
 
     function toHtml() {
         return $this->display('html');
+    }
+
+    function prepend($what) {
+        $this->body = $what . $this->body;
+    }
+
+    function append($what) {
+        $this->body .= $what;
     }
 
     function asVar() {


### PR DESCRIPTION
If the system receives an email by a collaborator which has not yet been added to the ticket (a friend of a friend — that is, a collaborator forwards an email to a third-party), a header is added to the thread body something like:
```
Received From: afriendofafriend@anothercompany.tld
```
However, if the thread body is text and the HTML ticket thread is enabled, then the text formatting hint will be lost and the body will be assumed as HTML deeper inside the thread entry creation process. Therefore, the whitespace inside the resulting thread entry will be collapsed.

This patch addresses the issue by maintaining the original format hint with the thread body.