### PR TITLE
Set system default timezone to Olsen on upgrade

### DIFF
--- a/include/i18n/en_US/config.yaml
+++ b/include/i18n/en_US/config.yaml
@@ -8,7 +8,6 @@ core:
     date_format: 'm/d/Y'
     datetime_format: 'm/d/Y g:i a'
     daydatetime_format: 'D, M j Y g:ia'
-    default_timezone_id: 8
     default_priority_id: 2
     enable_daylight_saving: 0
 

--- a/include/upgrader/streams/core/b26f29a6-1ee831c8.cleanup.sql
+++ b/include/upgrader/streams/core/b26f29a6-1ee831c8.cleanup.sql
@@ -17,3 +17,6 @@ ALTER TABLE `%TABLE_PREFIX%staff`
 ALTER TABLE `%TABLE_PREFIX%user_account`
     DROP `timezone_id`,
     DROP `dst`;
+
+DELETE FROM `%TABLE_PREFIX%config`
+    WHERE `key` = 'enable_daylight_saving' AND `namespace` = 'core';

--- a/include/upgrader/streams/core/b26f29a6-1ee831c8.cleanup.sql
+++ b/include/upgrader/streams/core/b26f29a6-1ee831c8.cleanup.sql
@@ -19,4 +19,5 @@ ALTER TABLE `%TABLE_PREFIX%user_account`
     DROP `dst`;
 
 DELETE FROM `%TABLE_PREFIX%config`
-    WHERE `key` = 'enable_daylight_saving' AND `namespace` = 'core';
+    WHERE `key` = IN ('enable_daylight_saving', 'default_timezone_id')
+      AND `namespace` = 'core';

--- a/include/upgrader/streams/core/b26f29a6-1ee831c8.patch.sql
+++ b/include/upgrader/streams/core/b26f29a6-1ee831c8.patch.sql
@@ -167,6 +167,11 @@ UPDATE `%TABLE_PREFIX%config` A1
     WHERE A1.`key` = 'default_timezone_id'
       AND A1.`namespace` = 'core';
 
+UPDATE `%TABLE_PREFIX%config` A1
+    SET A1.`key` = 'default_timezone'
+    WHERE A1.`key` = 'default_timezone_id'
+      AND A1.`namespace` = 'core';
+
 DROP TABLE %TABLE_PREFIX%_timezones;
 
 ALTER TABLE `%TABLE_PREFIX%ticket`

--- a/include/upgrader/streams/core/b26f29a6-1ee831c8.patch.sql
+++ b/include/upgrader/streams/core/b26f29a6-1ee831c8.patch.sql
@@ -146,6 +146,27 @@ UPDATE `%TABLE_PREFIX%user_account` A1
         AND A3.`south` = 0)
     SET A1.`timezone` = A3.`olson_name`;
 
+-- Update system default timezone
+SET @default_timezone_id = (
+    SELECT `value` FROM `%TABLE_PREFIX%config` A1
+    WHERE A1.`key` = 'default_timezone_id'
+      AND A1.`namespace` = 'core'
+);
+SET @enable_daylight_saving = (
+    SELECT `value` FROM `%TABLE_PREFIX%config` A1
+    WHERE A1.`key` = 'enable_daylight_saving'
+      AND A1.`namespace` = 'core'
+);
+
+UPDATE `%TABLE_PREFIX%config` A1
+    JOIN `%TABLE_PREFIX%timezone` A2 ON (@default_timezone_id = A2.`id`)
+    JOIN `%TABLE_PREFIX%_timezones` A3 ON (A2.`offset` * 60 = A3.`offset`
+        AND @enable_daylight_saving = A3.`dst`
+        AND A3.`south` = 0)
+    SET A1.`value` = A3.`olson_name`
+    WHERE A1.`key` = 'default_timezone_id'
+      AND A1.`namespace` = 'core';
+
 DROP TABLE %TABLE_PREFIX%_timezones;
 
 ALTER TABLE `%TABLE_PREFIX%ticket`

--- a/setup/inc/class.installer.php
+++ b/setup/inc/class.installer.php
@@ -209,7 +209,7 @@ class Installer extends SetupWizard {
                 'alert_email_id'=>$alert_email_id,
                 'default_dept_id'=>$dept_id_1, 'default_sla_id'=>$sla_id_1,
                 'default_template_id'=>$template_id_1,
-                'default_timezone' => date_default_timezone_get(),
+                'default_timezone' => $vars['timezone'] ?: date_default_timezone_get(),
                 'admin_email'=>$vars['admin_email'],
                 'schema_signature'=>$streams['core'],
                 'helpdesk_url'=>URL,

--- a/setup/inc/footer.inc.php
+++ b/setup/inc/footer.inc.php
@@ -3,5 +3,10 @@
         </div> <!-- content -->
     </div> <!-- wizard -->
     <div id="footer" class="centered">Copyright &copy; 2013 <a target="_blank" href="http://osticket.com">osTicket.com</a></div>
+
+    <script type="text/javascript" src="../js/jquery-1.11.2.min.js"></script>
+    <script type="text/javascript" src="../js/jstz.min.js"></script>
+    <script type="text/javascript" src="js/setup.js"></script>
+    <script type="text/javascript" src="js/tips.js"></script>
 </body>
 </html>

--- a/setup/inc/header.inc.php
+++ b/setup/inc/header.inc.php
@@ -11,9 +11,6 @@ if (($lang = Internationalization::getCurrentLanguage())
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <link rel="stylesheet" href="css/wizard.css">
     <link type="text/css" rel="stylesheet" href="<?php echo ROOT_PATH; ?>css/flags.css">
-    <script type="text/javascript" src="../js/jquery-1.8.3.min.js"></script>
-    <script type="text/javascript" src="js/tips.js"></script>
-    <script type="text/javascript" src="js/setup.js"></script>
 </head>
 <body>
     <div id="wizard">

--- a/setup/inc/install.inc.php
+++ b/setup/inc/install.inc.php
@@ -115,6 +115,8 @@ $info=($_POST && $errors)?Format::htmlchars($_POST):array('prefix'=>'ost_','dbho
                 <div id="bar">
                     <input class="btn" type="submit" value="<?php echo __('Install Now');?>" tabindex="14">
                 </div>
+
+                <input type="hidden" name="timezone" id="timezone"/>
             </form>
     </div>
     <div>

--- a/setup/js/setup.js
+++ b/setup/js/setup.js
@@ -1,5 +1,5 @@
 jQuery(function($) {
-            
+
     $("#overlay").css({
         opacity : 0.3,
         top     : 0,
@@ -12,10 +12,18 @@ jQuery(function($) {
         top  : ($(window).height() / 3),
         left : ($(window).width() / 2 - 160)
         });
-        
+
     $('form#install').submit(function(e) {
         $('input[type=submit]', this).attr('disabled', 'disabled');
         $('#overlay, #loading').show();
         return true;
         });
+
+    var recheck = setInterval(function() {
+        if (window.jstz !== undefined) {
+            clearInterval(recheck);
+            var zone = jstz.determine();
+            $('#timezone').val(zone.name());
+        }
+    }, 200);
 });


### PR DESCRIPTION
* [x] Change `default_timezone_id` to `default_timezone`
* [x] Auto-detect and set timezone on install (remove from yaml file)
* [x] Test upgrade from < 1.9-next
* [ ] Drop default_timezone_id from language packs on Crowdin