### PR TITLE
i18n: Missing translation "Add Organization"

### DIFF
--- a/include/staff/user-view.inc.php
+++ b/include/staff/user-view.inc.php
@@ -95,7 +95,7 @@ $org = $user->getOrganization();
                                         $user->getId(), $org->getName());
                             else
                                 echo sprintf('<a href="#users/%d/org"
-                                        class="user-action">Add Organization</a>',
+                                        class="user-action"><?php echo __('Add Organization'); ?></a>',
                                         $user->getId());
                         ?>
                         </span>


### PR DESCRIPTION
See: http://osticket.com/forum/discussion/85083/osticket-sends-no-html-mails#latest

Looked at crowdin and the term "Add Organization" is already used in the following context:
#: include/staff/templates/org-lookup.tmpl.php:82

So my suggestion is to use it also for this context here, which would not require a new translation ;)

Michael