### PR TITLE
Fix bad plain text initial ticket's internal note

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1915,9 +1915,6 @@ class Ticket {
     function logNote($title, $note, $poster='SYSTEM', $alert=true) {
 
         $errors = array();
-        //Unless specified otherwise, assume HTML
-        if ($note && is_string($note))
-            $note = new HtmlThreadBody($note);
 
         return $this->postNote(
                 array(


### PR DESCRIPTION
When we created a new ticket with a internal note this is processed
as HTML by default without check if HTML Thread is enabled or not.

The issue is than not convert newlines (\n) to line break (<br>)
and show the internal post with its properly line breaks.