### PR TITLE
filter: Trim match values when saving rules

### DIFF
--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -456,7 +456,7 @@ class Filter {
 
                 else //for everything-else...we assume it's valid.
                     $rules[]=array('what'=>$vars["rule_w$i"],
-                        'how'=>$vars["rule_h$i"],'val'=>$vars["rule_v$i"]);
+                        'how'=>$vars["rule_h$i"],'val'=>trim($vars["rule_v$i"]));
             }elseif($vars["rule_v$i"]) {
                 $errors["rule_$i"]=__('Incomplete selection');
             }


### PR DESCRIPTION
This will help when saving rules with trailing spaces for instance, which may make things not match when visually the administrator would otherwise expect the filter to match.