### PR TITLE
search: Fix search on create date

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -391,6 +391,7 @@ var scp_prep = function() {
         var fObj = $(this);
         var elem = $('#advanced-search');
         $('#result-count').html('');
+        fixupDatePickers.call(this);
         $.ajax({
                 url: "ajax.php/tickets/search",
                 data: fObj.serialize(),
@@ -447,18 +448,21 @@ var scp_prep = function() {
 
 $(document).ready(scp_prep);
 $(document).on('pjax:end', scp_prep);
-$(document).on('submit', 'form', function() {
+var fixupDatePickers = function() {
     // Reformat dates
     $('.dp', $(this)).each(function(i, e) {
         var $e = $(e),
             d = $e.datepicker('getDate');
-        if (!d) return;
+        if (!d || $e.data('fixed')) return;
         var day = ('0'+d.getDate()).substr(-2),
             month = ('0'+(d.getMonth()+1)).substr(-2),
             year = d.getFullYear();
         $e.val(year+'-'+month+'-'+day);
+        $e.data('fixed', true);
+        $e.on('change', function() { $(this).data('fixed', false); });
     });
-});
+};
+$(document).on('submit', 'form', fixupDatePickers);
 
     /************ global inits *****************/
 


### PR DESCRIPTION
This addresses the issue where the advanced search dialog was submitted before the date picker inputs were fixed up. This problem arises out of a difference between the agent's date formatting preference and the server being able to process that date format. The date pickers are reformated to yyyy-mm-dd before submission; however, for advanced search, the submission happened before the inputs were fixed up.

This patch addresses the issue by manually fixing up the date in the submission routine for the advanced search dialog.

Maybe fixes #901
Maybe fixes #690
Maybe fixes #1499