### PR TITLE
alerts: Consider "alert assigned on new message"

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1718,8 +1718,7 @@ class Ticket {
                 $recipients[]=$this->getLastRespondent();
 
             //Assigned staff if any...could be the last respondent
-
-            if ($this->isAssigned()) {
+            if ($cfg->alertAssignedONNewMessage() && $this->isAssigned()) {
                 if ($staff = $this->getStaff())
                     $recipients[] = $staff;
                 elseif ($team = $this->getTeam())


### PR DESCRIPTION
When sending alerts to agents, consider the setting of the new message alert configuration.

Fixes #1849