### PR TITLE
dashboard: Fix initial page load and stats pagination

### DIFF
--- a/include/ajax.config.php
+++ b/include/ajax.config.php
@@ -20,7 +20,7 @@ class ConfigAjaxAPI extends AjaxController {
 
     //config info UI might need.
     function scp() {
-        global $cfg;
+        global $cfg, $thisstaff;
 
         $lang = Internationalization::getCurrentLanguage();
         list($sl, $locale) = explode('_', $lang);
@@ -38,6 +38,7 @@ class ConfigAjaxAPI extends AjaxController {
               'lang'            => $lang,
               'short_lang'      => $sl,
               'has_rtl'         => $rtl,
+              'page_size'       => $thisstaff->getPageLimit(),
         );
         return $this->json_encode($config);
     }

--- a/include/class.nav.php
+++ b/include/class.nav.php
@@ -113,7 +113,7 @@ class StaffNav {
     function getTabs(){
         if(!$this->tabs) {
             $this->tabs=array();
-            $this->tabs['dashboard'] = array('desc'=>__('Dashboard'),'href'=>'dashboard.php','title'=>__('Agent Dashboard'));
+            $this->tabs['dashboard'] = array('desc'=>__('Dashboard'),'href'=>'dashboard.php','title'=>__('Agent Dashboard'), "class"=>"no-pjax");
             $this->tabs['users'] = array('desc' => __('Users'), 'href' => 'users.php', 'title' => __('User Directory'));
             $this->tabs['tickets'] = array('desc'=>__('Tickets'),'href'=>'tickets.php','title'=>__('Ticket Queue'));
             $this->tabs['kbase'] = array('desc'=>__('Knowledgebase'),'href'=>'kb.php','title'=>__('Knowledgebase'));

--- a/include/staff/templates/navigation.tmpl.php
+++ b/include/staff/templates/navigation.tmpl.php
@@ -1,7 +1,10 @@
 <?php
 if(($tabs=$nav->getTabs()) && is_array($tabs)){
     foreach($tabs as $name =>$tab) {
-        echo sprintf('<li class="%s"><a href="%s">%s</a>',$tab['active']?'active':'inactive',$tab['href'],$tab['desc']);
+        echo sprintf('<li class="%s %s"><a href="%s">%s</a>',
+            $tab['active'] ? 'active':'inactive',
+            @$tab['class'] ?: '',
+            $tab['href'],$tab['desc']);
         if(!$tab['active'] && ($subnav=$nav->getSubMenu($name))){
             echo "<ul>\n";
             foreach($subnav as $k => $item) {

--- a/scp/js/dashboard.inc.js
+++ b/scp/js/dashboard.inc.js
@@ -1,5 +1,5 @@
 (function ($) {
-    var current_tab;
+    var current_tab = null;
     function refresh(e) {
         $('#line-chart-here').empty();
         $('#line-chart-legend').empty();
@@ -135,6 +135,9 @@
             stop = this.period.value || 'now';
         }
 
+        if (!current_tab)
+            current_tab = $('#tabular-navigation li:first-child a');
+
         var group = current_tab.attr('table-group');
         var pagesize = 25;
         getConfig().then(function(c) { if (c.page_size) pagesize = c.page_size; });
@@ -262,10 +265,11 @@
         });
         return false;
     }
-   
-    $(function() { 
-        $('#timeframe-form').submit(refresh);
+
+    $(function() {
+        var form = $('#timeframe-form');
+        form.submit(refresh);
         //Trigger submit now...init.
-        $('#timeframe-form').submit(); 
-        });
+        form.submit();
+    });
 })(window.jQuery);


### PR DESCRIPTION
This patch addresses the issue where PJAX permanently breaks the loading order of scripts. Therefore the Raphael library currently used for the graph visualization is not loaded properly with PJAX. Therefore, PJAX is simply disabled on the dashboard page.

This also properly implements pagination for the statistics detail tabs, which seems to have been broken along the development trail somewhere.

Fixes #1853
Fixes #1828