### PR TITLE
csv: Add UTF-8 BOM to export file

### DIFF
--- a/include/class.export.php
+++ b/include/class.export.php
@@ -276,6 +276,7 @@ class CsvResultsExporter extends ResultSetExporter {
         if (!$this->output)
              $this->output = fopen('php://output', 'w');
 
+        fputs($this->output, chr(0xEF) . chr(0xBB) . chr(0xBF));
         fputcsv($this->output, $this->getHeaders());
         while ($row=$this->next())
             fputcsv($this->output, $row);


### PR DESCRIPTION
Because CSV has no way of indicating a content character set, writing the file with a Unicode byte-order mark is useful to declare the content in UTF-8 encoding.

Fixes #1526