### PR TITLE
email: Use \n as the default line ending

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -326,24 +326,12 @@ class Mailer {
                 $reply_tag = $cfg->getReplySeparator() . '<br/><br/>';
         }
 
-        // Use Mail_mime default initially
-        $eol = null;
+        // Use general failsafe default initially
+        $eol = "\n";
 
         // MAIL_EOL setting can be defined in `ost-config.php`
         if (defined('MAIL_EOL') && is_string(MAIL_EOL)) {
             $eol = MAIL_EOL;
-        }
-        // The Suhosin patch will muck up the line endings in some
-        // cases
-        //
-        // References:
-        // https://github.com/osTicket/osTicket-1.8/issues/202
-        // http://pear.php.net/bugs/bug.php?id=12032
-        // http://us2.php.net/manual/en/function.mail.php#97680
-        elseif ((extension_loaded('suhosin') || defined("SUHOSIN_PATCH"))
-            && !$this->getSMTPInfo()
-        ) {
-            $eol = "\n";
         }
         $mime = new Mail_mime($eol);
 

--- a/include/ost-sampleconfig.php
+++ b/include/ost-sampleconfig.php
@@ -71,7 +71,7 @@ define('TABLE_PREFIX','%CONFIG-PREFIX');
 #
 # Mail Options
 # ---------------------------------------------------
-# Option: MAIL_EOL (default: \r\n)
+# Option: MAIL_EOL (default: \n)
 #
 # Some mail setups do not handle emails with \r\n (CRLF) line endings for
 # headers and base64 and quoted-response encoded bodies. This is an error
@@ -88,7 +88,7 @@ define('TABLE_PREFIX','%CONFIG-PREFIX');
 # https://github.com/osTicket/osTicket-1.8/issues/759
 # https://github.com/osTicket/osTicket-1.8/issues/1217
 
-# define(MAIL_EOL, "\n");
+# define(MAIL_EOL, "\r\n");
 
 #
 # HTTP Server Options


### PR DESCRIPTION
It seems that most systems handle the newline character alone without a problem; however, some systems cannot handle the standard CRLF line ending at all.