### PR TITLE
forms: Add choice lookup support

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -1508,6 +1508,21 @@ class SelectionField extends FormField {
         return $selection;
     }
 
+    function lookupChoice($value) {
+
+        // See if it's in the choices.
+        $choices = $this->getChoices();
+        if ($choices && ($i=array_search($value, $choices)))
+            return array($i=>$choices[$i]);
+
+        // Query the store by value or extra (abbrv.)
+        if (($list=$this->getList()) && ($i=$list->getItem($value)))
+            return array($i->getId() => $i->getValue());
+
+        return null;
+    }
+
+
     function getFilterData() {
         // Start with the filter data for the list item as the [0] index
         $data = array(parent::getFilterData());

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1219,6 +1219,10 @@ class ChoiceField extends FormField {
         return $this->_choices;
     }
 
+    function lookupChoice($value) {
+        return null;
+    }
+
     function getSearchMethods() {
         return array(
             'set' =>        __('has a value'),
@@ -2335,11 +2339,8 @@ class TextboxSelectionWidget extends TextboxWidget {
     function getValue() {
 
         $value = parent::getValue();
-        if (($i=$this->field->getList()->getItem((string) $value)))
-            $value = array($i->getId() => $i->getValue());
-        elseif (($choices=$this->field->getChoices())
-                && ($k=array_search($value, $choices)))
-            $value = array($k => $choices[$k]);
+        if ($value && ($item=$this->field->lookupChoice((string) $value)))
+            $value = $item;
 
         return $value;
     }
@@ -2509,6 +2510,8 @@ class ChoicesWidget extends Widget {
             foreach($value as $k => $v) {
                 if (isset($choices[$v]))
                     $values[$v] = $choices[$v];
+                elseif (($i=$this->field->lookupChoice($v)))
+                    $values += $i;
             }
         }
 

--- a/include/class.list.php
+++ b/include/class.list.php
@@ -231,13 +231,15 @@ class DynamicList extends VerySimpleModel implements CustomList {
 
     function getItem($val) {
 
-        $criteria = array('list_id' => $this->getId());
-        if (is_int($val))
-            $criteria['id'] = $val;
-        else
-            $criteria['value'] = $val;
+        $items = DynamicListItem::objects()->filter(
+                array('list_id' => $this->getId()));
 
-         return DynamicListItem::lookup($criteria);
+        if (is_int($val))
+            $items->filter(array('id' => $val));
+        else
+            $items->filter(Q::any(array('value'=>$val, 'extra' => $val)));
+
+        return $items->first();
     }
 
     function addItem($vars, &$errors) {


### PR DESCRIPTION
Support using value or abbreviation for choice/selection input fields. API calls can now use list value or it's abbreviation instead of internal numeric IDs.

For example API calls can now us "LA" or "Louisiana" as input for a state list field.
