### PR TITLE
email: Some bounce notices actually have rich content

### DIFF
--- a/include/class.api.php
+++ b/include/class.api.php
@@ -297,7 +297,12 @@ class ApiController {
             $msg.="\n*[".$_SERVER['HTTP_X_API_KEY']."]*\n";
         $ost->logWarning(__('API Error')." ($code)", $msg, false);
 
-        $this->response($code, $error); //Responder should exit...
+        if (PHP_SAPI == 'cli') {
+            fwrite(STDERR, "({$code}) $error\n");
+        }
+        else {
+            $this->response($code, $error); //Responder should exit...
+        }
         return false;
     }
 

--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -642,7 +642,7 @@ class MailFetcher {
                 $vars['in-reply-to'] = @$headers['in-reply-to'] ?: null;
             }
             // Fetch deliver status report
-            $vars['message'] = $this->getDeliveryStatusMessage($mid);
+            $data['message'] = $this->getDeliveryStatusMessage($mid) ?: $this->getBody($mid);
             $vars['thread-type'] = 'N';
             $vars['flags']['bounce'] = true;
         }

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -657,7 +657,7 @@ class EmailDataParser {
                 $data['in-reply-to'] = @$headers['in-reply-to'] ?: null;
             }
             // Fetch deliver status report
-            $data['message'] = $parser->getDeliveryStatusMessage();
+            $data['message'] = $parser->getDeliveryStatusMessage() ?: $parser->getBody();
             $data['thread-type'] = 'N';
             $data['flags']['bounce'] = true;
         }

--- a/include/class.mailparse.php
+++ b/include/class.mailparse.php
@@ -275,10 +275,9 @@ class Mail_Parse {
             && isset($this->struct->ctype_parameters['report-type'])
             && $this->struct->ctype_parameters['report-type'] == 'delivery-status'
         ) {
-            return sprintf('<pre>%s</pre>',
-                Format::htmlchars(
-                    $this->getPart($this->struct, 'text/plain', 1)
-                ));
+            return new TextThreadBody(
+                $this->getPart($this->struct, 'text/plain', 1)
+            );
         }
         return false;
     }


### PR DESCRIPTION
Here's an example email structure:
```
multipart/mixed
 - multipart/report; delivery-status
   - multipart/alternative
     - text/plain
     - text/html
   - message/delivery-status
   - message/rfc822
```

The previous code would only find the body if the email main headers had: `Content-Type: multipart/report; report-type="delivery-status"`. In such a case it would scan for a plain/text body.

This patch will scan for the usual body if the scan for the body as usual if the report scan did not find anything.

Also, output errors to stderr when running API from the command line