### PR TITLE
email: Add warning for archive folder for POP

### DIFF
--- a/include/class.email.php
+++ b/include/class.email.php
@@ -296,8 +296,12 @@ class Email {
 
             if(!isset($vars['postfetch']))
                 $errors['postfetch']=__('Indicate what to do with fetched emails');
-            elseif(!strcasecmp($vars['postfetch'],'archive') && !$vars['mail_archivefolder'] )
-                $errors['postfetch']=__('Valid folder required');
+            elseif(!strcasecmp($vars['postfetch'],'archive')) {
+                if ($vars['mail_protocol'] == 'POP')
+                    $errors['postfetch'] =  __('POP mail servers do not support folders');
+                elseif (!$vars['mail_archivefolder'])
+                    $errors['postfetch'] = __('Valid folder required');
+            }
         }
 
         if($vars['smtp_active']) {

--- a/include/staff/email.inc.php
+++ b/include/staff/email.inc.php
@@ -218,7 +218,7 @@ $info=Format::htmlchars(($errors && $_POST)?$_POST:$info);
             <td>
 		<span>
 			<select name="mail_proto">
-                <option value=''>&mdash; <?php __('Select protocol'); ?> &mdash;</option>
+                <option value=''>&mdash; <?php echo __('Select protocol'); ?> &mdash;</option>
 <?php
     foreach (MailFetcher::getSupportedProtos() as $proto=>$desc) { ?>
                 <option value="<?php echo $proto; ?>" <?php


### PR DESCRIPTION
This patch adds an error to the page if unable to configure the archive folder and POP was selected as the mailbox protocol. Generally, POP servers do not support anything but the INBOX