### PR TITLE
Unassign on transfer

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -246,6 +246,16 @@ class Dept {
         return ($this->getManagerId() && $this->getManagerId()==$staff);
     }
 
+    function isMember($staff) {
+
+        if (is_object($staff))
+            $staff = $staff->getId();
+
+        // Members are indexed by ID
+        $members = $this->getMembers();
+
+        return ($members && isset($members[$staff]));
+    }
 
     function isPublic() {
          return ($this->ht['ispublic']);

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1559,10 +1559,20 @@ class Ticket {
         if($this->isClosed()) $this->reopen();
 
         $this->reload();
+        $dept = $this->getDept();
 
         // Set SLA of the new department
         if(!$this->getSLAId() || $this->getSLA()->isTransient())
             $this->selectSLAId();
+
+        // Make sure the new department allows assignment to the
+        // currently assigned agent (if any)
+        if ($this->isAssigned()
+                && ($staff=$this->getStaff())
+                && $dept->assignMembersOnly()
+                && !$dept->isMember($staff)) {
+            $this->setStaffId(0);
+        }
 
         /*** log the transfer comments as internal note - with alerts disabled - ***/
         $title=sprintf(_S('Ticket transferred from %1$s to %2$s'),
@@ -1573,7 +1583,7 @@ class Ticket {
         $this->logEvent('transferred');
 
         //Send out alerts if enabled AND requested
-        if(!$alert || !$cfg->alertONTransfer() || !($dept=$this->getDept()))
+        if (!$alert || !$cfg->alertONTransfer())
             return true; //no alerts!!
 
          if (($email = $dept->getAlertEmail())
@@ -1614,6 +1624,21 @@ class Ticket {
          }
 
          return true;
+    }
+
+    function claim() {
+        global $thisstaff;
+
+        if (!$thisstaff || !$this->isOpen() || $this->isAssigned())
+            return false;
+
+        $dept = $this->getDept();
+        if ($dept->assignMembersOnly() && !$dept->isMember($thisstaff))
+            return false;
+
+        $comments = sprintf(__('Ticket claimed by %s'), $thisstaff->getName());
+
+        return $this->assignToStaff($thisstaff->getId(), $comments, false);
     }
 
     function assignToStaff($staff, $note, $alert=true) {
@@ -1933,6 +1958,7 @@ class Ticket {
                 && $vars['reply_status_id'] != $this->getStatusId())
             $this->setStatus($vars['reply_status_id']);
 
+        // Claim on response bypasses the department assignment restrictions
         if($thisstaff && $this->isOpen() && !$this->getStaffId()
                 && $cfg->autoClaimTickets())
             $this->setStaffId($thisstaff->getId()); //direct assignment;

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -76,7 +76,10 @@ if($ticket->isOverdue())
                     echo __('Edit'); ?></a>
             <?php
             }
-            if ($ticket->isOpen() && !$ticket->isAssigned() && $thisstaff->canAssignTickets()) {?>
+            if ($ticket->isOpen()
+                    && !$ticket->isAssigned()
+                    && $thisstaff->canAssignTickets()
+                    && $ticket->getDept()->isMember($thisstaff)) {?>
                 <a id="ticket-claim" class="action-button pull-right confirm-action" href="#claim"><i class="icon-user"></i> <?php
                     echo __('Claim'); ?></a>
 
@@ -803,7 +806,9 @@ print $note_form->getField('attachments')->render();
                     <select id="assignId" name="assignId">
                         <option value="0" selected="selected">&mdash; <?php echo __('Select an Agent OR a Team');?> &mdash;</option>
                         <?php
-                        if($ticket->isOpen() && !$ticket->isAssigned())
+                        if ($ticket->isOpen()
+                                && !$ticket->isAssigned()
+                                && $ticket->getDept()->isMember($thisstaff))
                             echo sprintf('<option value="%d">'.__('Claim Ticket (comments optional)').'</option>', $thisstaff->getId());
 
                         $sid=$tid=0;


### PR DESCRIPTION
Unassign tickets on transfer when the target department has assignment restriction and the assigned staff is not a member.

Disable claim (quick self-assignment) when above restriction is in effect.