### PR TITLE
Unassign on transfer

### DIFF
--- a/include/class.dept.php
+++ b/include/class.dept.php
@@ -246,6 +246,16 @@ class Dept {
         return ($this->getManagerId() && $this->getManagerId()==$staff);
     }
 
+    function isMember($staff) {
+
+        if (is_object($staff))
+            $staff = $staff->getId();
+
+        // Members are indexed by ID
+        $members = $this->getMembers();
+
+        return ($members && isset($members[$staff]));
+    }
 
     function isPublic() {
          return ($this->ht['ispublic']);

--- a/include/i18n/en_US/help/tips/staff.department.yaml
+++ b/include/i18n/en_US/help/tips/staff.department.yaml
@@ -73,9 +73,9 @@ sandboxing:
     title: Ticket Assignment Restrictions
     content: >
         Enable this to restrict ticket assignement to only include members
-        of this Department. Department access can be extended to
-        Groups, if <span class="doc-desc-title">Group Membership</span> is
-        also enabled.
+        of this Department. Department membership can be extended to Groups,
+        if <span class="doc-desc-title">Alerts &amp; Notices
+        Recipients</span> includes groups members.
 
 auto_response_settings:
     title: Autoresponder Settings

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -76,7 +76,10 @@ if($ticket->isOverdue())
                     echo __('Edit'); ?></a>
             <?php
             }
-            if ($ticket->isOpen() && !$ticket->isAssigned() && $thisstaff->canAssignTickets()) {?>
+            if ($ticket->isOpen()
+                    && !$ticket->isAssigned()
+                    && $thisstaff->canAssignTickets()
+                    && $ticket->getDept()->isMember($thisstaff)) {?>
                 <a id="ticket-claim" class="action-button pull-right confirm-action" href="#claim"><i class="icon-user"></i> <?php
                     echo __('Claim'); ?></a>
 
@@ -803,7 +806,9 @@ print $note_form->getField('attachments')->render();
                     <select id="assignId" name="assignId">
                         <option value="0" selected="selected">&mdash; <?php echo __('Select an Agent OR a Team');?> &mdash;</option>
                         <?php
-                        if($ticket->isOpen() && !$ticket->isAssigned())
+                        if ($ticket->isOpen()
+                                && !$ticket->isAssigned()
+                                && $ticket->getDept()->isMember($thisstaff))
                             echo sprintf('<option value="%d">'.__('Claim Ticket (comments optional)').'</option>', $thisstaff->getId());
 
                         $sid=$tid=0;


### PR DESCRIPTION
Unassign tickets on transfer when the target department has assignment restriction and the assigned staff is not a member. Also disable claim (quick self-assignment) when the restriction is in effect.