### PR TITLE
forms: Don't update CDATA when updating old fields

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -349,6 +349,9 @@ class TicketForm extends DynamicForm {
             return;
 
         $f = $answer->getField();
+        if (!$f->getFormId())
+            return;
+
         $name = $f->get('name') ?: ('field_'.$f->get('id'));
         $fields = sprintf('`%s`=', $name) . db_input(
             implode(',', $answer->getSearchKeys()));
@@ -469,6 +472,9 @@ class DynamicFormField extends VerySimpleModel {
     }
 
     function getAnswer() { return $this->answer; }
+
+    function getForm() { return $this->form; }
+    function getFormId() { return $this->form_id; }
 
     /**
      * setConfiguration


### PR DESCRIPTION
If an update to an object such as a ticket results in a corresponding update to the CDATA table, and one or more of the fields have been deleted from the ticket details form, then, avoid updating the CDATA table for those fields.

This fixes an issue where the CDATA table is dropped and recreated when fields are added and removed from the form. The table will only contain fields which are currently on the form when the table is created. Therefore, deleted fields will never be on the CDATA table and will result in an SQL error.