### PR TITLE
Feature :: Dynamic Forms 1.1 — address major confusion and magic issues

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -57,7 +57,7 @@ class Bootstrap {
                 && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https');
     }
 
-    function defineTables($prefix) {
+    static function defineTables($prefix) {
         #Tables being used sytem wide
         define('SYSLOG_TABLE',$prefix.'syslog');
         define('SESSION_TABLE',$prefix.'session');

--- a/include/class.company.php
+++ b/include/class.company.php
@@ -48,7 +48,7 @@ class Company {
     }
 
     function getInfo() {
-        return $this->getForm()->getSaved();
+        return $this->getForm()->getClean();
     }
 
     function getName() {

--- a/include/class.draft.php
+++ b/include/class.draft.php
@@ -137,7 +137,7 @@ class Draft extends VerySimpleModel {
         return parent::save($refetch);
     }
 
-    static function create($vars) {
+    static function create($vars=false) {
         $attachments = @$vars['attachments'];
         unset($vars['attachments']);
 

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -61,6 +61,10 @@ class Form {
             return $fields[$name];
     }
 
+    function hasField($name) {
+        return $this->getField($name);
+    }
+
     function getTitle() { return $this->title; }
     function getInstructions() { return $this->instructions; }
     function getSource() { return $this->_source; }
@@ -102,6 +106,14 @@ class Form {
             unset($this->_clean[""]);
         }
         return $this->_clean;
+    }
+
+    function disableFields(array $ids) {
+        foreach ($this->getFields() as $F) {
+            if (in_array($F->get('id'), $ids)) {
+                $F->disable();
+            }
+        }
     }
 
     function errors($formOnly=false) {

--- a/include/class.list.php
+++ b/include/class.list.php
@@ -1299,7 +1299,9 @@ class TicketStatus  extends VerySimpleModel implements CustomListItem {
         return $this->getName();
     }
 
-    static function create($ht) {
+    static function create($ht=false) {
+        if (!is_array($ht))
+            return null;
 
         if (!isset($ht['mode']))
             $ht['mode'] = 1;

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -383,6 +383,7 @@ class VerySimpleModel {
         // First, if any foreign properties of this object are connected to
         // another *new* object, then save those objects first and set the
         // local foreign key field values
+        static::_inspect();
         foreach (static::$meta['joins'] as $prop => $j) {
             if (isset($this->ht[$prop]) 
                 && ($foreign = $this->ht[$prop])

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -357,7 +357,7 @@ class VerySimpleModel {
         }
     }
 
-    function delete($pk=false) {
+    function delete() {
         $ex = DbEngine::delete($this);
         try {
             $ex->execute();

--- a/include/class.orm.php
+++ b/include/class.orm.php
@@ -166,8 +166,7 @@ class VerySimpleModel {
                 static::_inspect();
             $j = static::$meta['joins'][$field];
             // Support instrumented lists and such
-            if (isset($this->ht[$j['local']])
-                    && isset($j['list']) && $j['list']) {
+            if (isset($j['list']) && $j['list']) {
                 $fkey = $j['fkey'];
                 $v = $this->ht[$field] = new InstrumentedList(
                     // Send Model, Foriegn-Field, Local-Id
@@ -252,11 +251,13 @@ class VerySimpleModel {
                 // Pass. Set local field to NULL in logic below
             }
             elseif ($value instanceof $j['fkey'][0]) {
-                if ($value->__new__)
-                    $value->save();
                 // Capture the object under the object's field name
                 $this->ht[$field] = $value;
-                $value = $value->get($j['fkey'][1]);
+                if ($value->__new__)
+                    // save() will be performed when saving this object
+                    $value = null;
+                else
+                    $value = $value->get($j['fkey'][1]);
                 // Fall through to the standard logic below
             }
             else
@@ -373,17 +374,38 @@ class VerySimpleModel {
     }
 
     function save($refetch=false) {
+        if ($this->__deleted__)
+            throw new OrmException('Trying to update a deleted object');
+
+        $pk = static::$meta['pk'];
+        $wasnew = $this->__new__;
+
+        // First, if any foreign properties of this object are connected to
+        // another *new* object, then save those objects first and set the
+        // local foreign key field values
+        foreach (static::$meta['joins'] as $prop => $j) {
+            if (isset($this->ht[$prop]) 
+                && ($foreign = $this->ht[$prop])
+                && $foreign instanceof VerySimpleModel
+                && !in_array($j['local'], $pk)
+                && null === $this->get($j['local'])
+            ) {
+                if ($foreign->__new__ && !$foreign->save())
+                    return false;
+                $this->set($j['local'], $foreign->get($j['fkey'][1]));
+            }
+        }
+
+        // If there's nothing in the model to be saved, then we're done
         if (count($this->dirty) === 0)
             return true;
-        elseif ($this->__deleted__)
-            throw new OrmException('Trying to update a deleted object');
 
         $ex = DbEngine::save($this);
         try {
             $ex->execute();
             if ($ex->affected_rows() != 1) {
                 // This doesn't really signify an error. It just means that
-                // the database believe that the row did not change. For
+                // the database believes that the row did not change. For
                 // inserts though, it's a deal breaker
                 if ($this->__new__)
                     return false;
@@ -397,10 +419,7 @@ class VerySimpleModel {
             return false;
         }
 
-        $pk = static::$meta['pk'];
-        $wasnew = $this->__new__;
-
-        if ($this->__new__) {
+        if ($wasnew) {
             if (count($pk) == 1)
                 // XXX: Ensure AUTO_INCREMENT is set for the field
                 $this->ht[$pk[0]] = $ex->insert_id();
@@ -412,19 +431,38 @@ class VerySimpleModel {
             Signal::send('model.updated', $this, $data);
         }
         # Refetch row from database
-        # XXX: Too much voodoo
         if ($refetch) {
-            // Uncache so that the lookup will not be short-cirtuited to
-            // return this object
-            ModelInstanceManager::uncache($this);
-            $self = call_user_func_array(array(get_class($this), 'lookup'),
-                $this->get('pk'));
-            $this->ht = $self->ht;
+            // Preserve non database information such as list relationships
+            // across the refetch
+            $this->ht = 
+                static::objects()->filter($this->getPk())->values()->one()
+                + $this->ht;
         }
-        if ($wasnew)
+        if ($wasnew) {
+            // Attempt to update foreign, unsaved objects with the PK of
+            // this newly created object
+            foreach (static::$meta['joins'] as $prop => $j) {
+                if (isset($this->ht[$prop]) 
+                    && ($foreign = $this->ht[$prop])
+                    && in_array($j['local'], $pk)
+                ) {
+                    if ($foreign instanceof VerySimpleModel
+                        && null === $foreign->get($j['fkey'][1])
+                    ) {
+                        $foreign->set($j['fkey'][1], $this->get($j['local']));
+                    }
+                    elseif ($foreign instanceof InstrumentedList) {
+                        foreach ($foreign as $item) {
+                            if (null === $item->get($j['fkey'][1]))
+                                $item->set($j['fkey'][1], $this->get($j['local']));
+                        }
+                    }
+                }
+            }
             $this->__onload();
+        }
         $this->dirty = array();
-        return $this->get($pk[0]);
+        return true;
     }
 
     static function create($ht=false) {
@@ -944,7 +982,7 @@ class QuerySet implements IteratorAggregate, ArrayAccess, Serializable, Countabl
         $query = clone $this;
         if (!$query->ordering && isset($model::$meta['ordering']))
             $query->ordering = $model::$meta['ordering'];
-        if (!$query->related && !$query->values && $model::$meta['select_related'])
+        if (false !== $query->related && !$query->values && $model::$meta['select_related'])
             $query->related = $model::$meta['select_related'];
         if (!$query->defer && $model::$meta['defer'])
             $query->defer = $model::$meta['defer'];
@@ -1275,15 +1313,17 @@ class InstrumentedList extends ModelInstanceManager {
             throw new Exception(__('Attempting to add invalid object to list'));
 
         $object->set($this->key, $this->id);
-        $object->save();
 
         if ($at !== false)
             $this->cache[$at] = $object;
         else
             $this->cache[] = $object;
     }
-    function remove($object) {
-        $object->delete();
+    function remove($object, $delete=true) {
+        if ($delete)
+            $object->delete();
+        else
+            $object->set($this->key, null);
     }
 
     function reset() {
@@ -2344,11 +2384,11 @@ class Q implements Serializable {
         return $this;
     }
 
-    static function not(array $constraints) {
+    static function not($constraints) {
         return new static($constraints, self::NEGATED);
     }
 
-    static function any(array $constraints) {
+    static function any($constraints) {
         return new static($constraints, self::ANY);
     }
 

--- a/include/class.sequence.php
+++ b/include/class.sequence.php
@@ -215,7 +215,7 @@ class RandomSequence extends Sequence {
     var $padding = '0';
 
     // Override the ORM constructor and do nothing
-    function __construct() {}
+    function __construct($ht=false) {}
 
     function __next($digits=6) {
         if ($digits < 6)
@@ -228,7 +228,7 @@ class RandomSequence extends Sequence {
         return $this->next($format);
     }
 
-    function save() {
+    function save($refetch=false) {
         throw new RuntimeException('RandomSequence is not database-backed');
     }
 }

--- a/include/class.task.php
+++ b/include/class.task.php
@@ -416,8 +416,11 @@ class Task extends TaskModel {
         return !self::lookupIdByNumber($number);
     }
 
-    static function create($vars) {
+    static function create($vars=false) {
         global $cfg;
+
+        if (!is_array($vars))
+            return null;
 
         $task = parent::create(array(
             'flags' => self::ISOPEN,

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1035,7 +1035,7 @@ class ThreadEntry extends VerySimpleModel {
     }
 
     //new entry ... we're trusting the caller to check validity of the data.
-    static function create($vars) {
+    static function create($vars, &$errors=array()) {
         global $cfg;
 
         //Must have...
@@ -1159,7 +1159,7 @@ class ThreadEntry extends VerySimpleModel {
         return $entry;
     }
 
-    static function add($vars) {
+    static function add($vars, &$errors=array()) {
         return self::create($vars);
     }
 
@@ -1443,11 +1443,11 @@ class MessageThreadEntry extends ThreadEntry {
         return $this->getTitle();
     }
 
-    static function create($vars, &$errors) {
+    static function create($vars, &$errors=array()) {
         return static::add($vars, $errors);
     }
 
-    static function add($vars, &$errors) {
+    static function add($vars, &$errors=array()) {
 
         if (!$vars || !is_array($vars) || !$vars['threadId'])
             $errors['err'] = __('Missing or invalid data');
@@ -1481,11 +1481,11 @@ class ResponseThreadEntry extends ThreadEntry {
         return $this->getStaff();
     }
 
-    static function create($vars, &$errors) {
+    static function create($vars, &$errors=array()) {
         return static::add($vars, $errors);
     }
 
-    static function add($vars, &$errors) {
+    static function add($vars, &$errors=array()) {
 
         if (!$vars || !is_array($vars) || !$vars['threadId'])
             $errors['err'] = __('Missing or invalid data');
@@ -1520,7 +1520,7 @@ class NoteThreadEntry extends ThreadEntry {
         return self::add($vars, $errors);
     }
 
-    static function add($vars, &$errors) {
+    static function add($vars, &$errors=array()) {
 
         //Check required params.
         if (!$vars || !is_array($vars) || !$vars['threadId'])

--- a/include/class.translation.php
+++ b/include/class.translation.php
@@ -1009,7 +1009,10 @@ class CustomDataTranslation extends VerySimpleModel {
         return parent::save($refetch);
     }
 
-    static function create(array $ht=array()) {
+    static function create($ht=false) {
+        if (!is_array($ht))
+            return null;
+
         if (is_array($ht['text'])) {
             // The parent constructor does not honor arrays
             $ht['text'] = static::encodeComplex($ht['text']);

--- a/include/staff/dynamic-form.inc.php
+++ b/include/staff/dynamic-form.inc.php
@@ -6,7 +6,7 @@ if($form && $_REQUEST['a']!='add') {
     $action = 'update';
     $url = "?id=".urlencode($_REQUEST['id']);
     $submit_text=__('Save Changes');
-    $info = $form->ht;
+    $info = $form->getInfo();
     $trans = array(
         'title' => $form->getTranslateTag('title'),
         'instructions' => $form->getTranslateTag('instructions'),

--- a/include/staff/templates/dynamic-form.tmpl.php
+++ b/include/staff/templates/dynamic-form.tmpl.php
@@ -24,7 +24,7 @@ if (isset($options['entry']) && $options['mode'] == 'edit') { ?>
 <?php if ($options['mode'] == 'edit') { ?>
         <div class="pull-right">
     <?php if ($options['entry']
-                && $options['entry']->getForm()->get('type') == 'G') { ?>
+                && $options['entry']->getDynamicForm()->get('type') == 'G') { ?>
             <a href="#" title="Delete Entry" onclick="javascript:
                 $(this).closest('tbody').remove();
                 return false;"><i class="icon-trash"></i></a>&nbsp;

--- a/include/staff/templates/form-manage.tmpl.php
+++ b/include/staff/templates/form-manage.tmpl.php
@@ -12,9 +12,9 @@ $current_list = array();
 foreach ($forms as $e) { ?>
 <div class="sortable row-item" data-id="<?php echo $e->get('id'); ?>">
     <input type="hidden" name="forms[]" value="<?php echo $e->get('form_id'); ?>" />
-    <i class="icon-reorder"></i> <?php echo $e->getForm()->getTitle();
+    <i class="icon-reorder"></i> <?php echo $e->getTitle();
     $current_list[] = $e->get('form_id');
-    if ($e->getForm()->get('type') == 'G') { ?>
+    if ($e->getDynamicForm()->get('type') == 'G') { ?>
     <div class="button-group">
     <div class="delete"><a href="#"><i class="icon-trash"></i></a></div>
     </div>

--- a/include/staff/templates/org.tmpl.php
+++ b/include/staff/templates/org.tmpl.php
@@ -28,7 +28,7 @@ if ($info['error']) {
 <?php foreach ($org->getDynamicData() as $entry) {
 ?>
     <tr><td colspan="2" style="border-bottom: 1px dotted black"><strong><?php
-         echo $entry->getForm()->get('title'); ?></strong></td></tr>
+         echo $entry->getTitle(); ?></strong></td></tr>
 <?php foreach ($entry->getAnswers() as $a) { ?>
     <tr style="vertical-align:top"><td style="width:30%;border-bottom: 1px dotted #ccc"><?php echo Format::htmlchars($a->getField()->get('label'));
          ?>:</td>

--- a/include/staff/templates/user-delete.tmpl.php
+++ b/include/staff/templates/user-delete.tmpl.php
@@ -35,7 +35,7 @@ if ($info['error']) {
 <?php foreach ($user->getDynamicData() as $entry) {
 ?>
     <tr><td colspan="2" style="border-bottom: 1px dotted black"><strong><?php
-         echo $entry->getForm()->get('title'); ?></strong></td></tr>
+         echo $entry->getTitle(); ?></strong></td></tr>
 <?php foreach ($entry->getAnswers() as $a) { ?>
     <tr style="vertical-align:top"><td style="width:30%;border-bottom: 1px dotted #ccc"><?php echo Format::htmlchars($a->getField()->get('label'));
          ?>:</td>

--- a/include/staff/templates/user-lookup.tmpl.php
+++ b/include/staff/templates/user-lookup.tmpl.php
@@ -44,7 +44,7 @@ if ($user) { ?>
     <table style="margin-top: 1em;">
 <?php foreach ($user->getDynamicData() as $entry) { ?>
     <tr><td colspan="2" style="border-bottom: 1px dotted black"><strong><?php
-         echo $entry->getForm()->get('title'); ?></strong></td></tr>
+         echo $entry->getTitle(); ?></strong></td></tr>
 <?php foreach ($entry->getAnswers() as $a) { ?>
     <tr style="vertical-align:top"><td style="width:30%;border-bottom: 1px dotted #ccc"><?php echo Format::htmlchars($a->getField()->get('label'));
          ?>:</td>

--- a/include/staff/templates/user.tmpl.php
+++ b/include/staff/templates/user.tmpl.php
@@ -62,7 +62,7 @@ if ($info['error']) {
 <?php foreach ($user->getDynamicData() as $entry) {
 ?>
     <tr><th colspan="2"><strong><?php
-         echo $entry->getForm()->get('title'); ?></strong></td></tr>
+         echo $entry->getTitle(); ?></strong></td></tr>
 <?php foreach ($entry->getAnswers() as $a) { ?>
     <tr><td style="width:30%;"><?php echo Format::htmlchars($a->getField()->get('label'));
          ?>:</td>
@@ -86,7 +86,7 @@ if ($info['error']) {
 <?php foreach ($org->getDynamicData() as $entry) {
 ?>
     <tr><th colspan="2"><strong><?php
-         echo $entry->getForm()->get('title'); ?></strong></td></tr>
+         echo $entry->getTitle(); ?></strong></td></tr>
 <?php foreach ($entry->getAnswers() as $a) { ?>
     <tr><td style="width:30%"><?php echo Format::htmlchars($a->getField()->get('label'));
          ?>:</td>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -350,10 +350,10 @@ foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
     // TODO: Rewrite getAnswers() so that one could write
     //       ->getAnswers()->filter(not(array('field__name__in'=>
     //           array('email', ...))));
-    $answers = array_filter($form->getAnswers(), function ($a) {
-        return !in_array($a->getField()->get('name'),
-                array('email','subject','name','priority'));
-        });
+    $answers = $form->getAnswers()->exclude(Q::any(array(
+        'field__flags__hasbit' => DynamicFormField::FLAG_EXT_STORED,
+        'field__name__in' => array('subject', 'priority')
+    )));
     if (count($answers) == 0)
         continue;
     ?>

--- a/include/upgrader/streams/core/b26f29a6-1ee831c8.patch.sql
+++ b/include/upgrader/streams/core/b26f29a6-1ee831c8.patch.sql
@@ -185,6 +185,11 @@ UPDATE `%TABLE_PREFIX%form_field` A1 JOIN `%TABLE_PREFIX%form` A2 ON(A2.id=A1.fo
     SET A1.`flags`=3
     WHERE A2.`type`='O' AND A1.`name` IN('name');
 
+-- Thread entry field is stored externally
+UPDATE `%TABLE_PREFIX%form_field` A1 JOIN `%TABLE_PREFIX%form` A2 ON(A2.id=A1.form_id)
+    SET A1.`flags`=3
+    WHERE A2.`type`='T' AND A1.`name` IN ('message');
+
 -- Coalesce to zero here in case the config option has never been saved
 set @client_edit = coalesce(
     (select value from `%TABLE_PREFIX%config` where `key` =

--- a/scp/forms.php
+++ b/scp/forms.php
@@ -113,7 +113,7 @@ if($_POST) {
                 'name'=>trim($_POST["name-new-$i"]),
             ));
             $field->setRequirementMode($_POST["visibility-new-$i"]);
-            $field->setForm($form);
+            $form->fields->add($field);
             if (in_array($field->get('name'), $names))
                 $field->addError(__('Field variable name is not unique'), 'name');
             if ($field->isValid()) {
@@ -124,9 +124,7 @@ if($_POST) {
             else
                 $errors["new-$i"] = $field->errors();
         }
-        // XXX: Move to an instrumented list that can handle this better
         if (!$errors) {
-            $form->_dfields = $form->_fields = null;
             $form->save(true);
             foreach ($form_fields as $field) {
                 $field->set('form_id', $form->get('id'));

--- a/scp/lists.php
+++ b/scp/lists.php
@@ -95,6 +95,7 @@ if($_POST) {
             break;
         case 'add':
             if ($list=DynamicList::add($_POST, $errors)) {
+                 $form = $list->getForm(true);
                  $msg = sprintf(__('Successfully added %s'),
                     __('this custom list'));
             } elseif ($errors) {
@@ -154,7 +155,6 @@ if($_POST) {
             if (!$_POST["prop-label-new-$i"])
                 continue;
             $field = DynamicFormField::create(array(
-                'form_id' => $form->get('id'),
                 'sort' => $_POST["prop-sort-new-$i"] ?: ++$max_sort,
                 'label' => $_POST["prop-label-new-$i"],
                 'type' => $_POST["type-new-$i"],
@@ -163,15 +163,13 @@ if($_POST) {
                     | DynamicFormField::FLAG_AGENT_VIEW
                     | DynamicFormField::FLAG_AGENT_EDIT,
             ));
-            $field->setForm($form);
-            if ($field->isValid())
+            if ($field->isValid()) {
+                $form->fields->add($field);
                 $field->save();
+            }
             else
                 $errors["new-$i"] = $field->errors();
         }
-        // XXX: Move to an instrumented list that can handle this better
-        if (!$errors)
-            $form->_dfields = $form->_fields = null;
     }
 }
 

--- a/setup/test/run-tests.php
+++ b/setup/test/run-tests.php
@@ -5,12 +5,8 @@ if (php_sapi_name() != 'cli') exit();
 //Allow user to select suite
 $selected_test = (isset($argv[1])) ? $argv[1] : false;
 
+require_once 'bootstrap.php';
 require_once "tests/class.test.php";
-
-$root = get_osticket_root_path();
-define('INCLUDE_DIR', "$root/include/");
-define('PEAR_DIR', INCLUDE_DIR."pear/");
-ini_set('include_path', './'.PATH_SEPARATOR.INCLUDE_DIR.PATH_SEPARATOR.PEAR_DIR);
 
 $fails = array();
 

--- a/setup/test/tests/mockdb.php
+++ b/setup/test/tests/mockdb.php
@@ -1,5 +1,9 @@
 <?php
 
+define('TABLE_PREFIX', '%');
+
+Bootstrap::defineTables(TABLE_PREFIX);
+
 function db_connect($source) {
     global $__db;
     $__db = $source;

--- a/setup/test/tests/test.header_functions.php
+++ b/setup/test/tests/test.header_functions.php
@@ -1,7 +1,5 @@
 <?php
 require_once "class.test.php";
-define('INCLUDE_DIR', realpath(dirname(__file__).'/../../../include').'/');
-define('PEAR_DIR', INCLUDE_DIR.'/pear/');
 require_once INCLUDE_DIR."class.mailparse.php";
 
 abstract class Priorities {

--- a/setup/test/tests/test.mail-parse.php
+++ b/setup/test/tests/test.mail-parse.php
@@ -1,13 +1,13 @@
 <?php
 
+require_once 'mockdb.php';
+
 require_once INCLUDE_DIR.'class.validator.php';
 require_once INCLUDE_DIR.'class.auth.php';
 require_once INCLUDE_DIR.'class.staff.php';
 require_once INCLUDE_DIR.'class.email.php';
 require_once INCLUDE_DIR.'class.format.php';
 require_once INCLUDE_DIR.'class.thread.php';
-
-require_once 'mockdb.php';
 
 class TestMailParsing extends Test {
     var $name = "Mail parsing library tests";


### PR DESCRIPTION
This feature addresses a major issue with the initial implementation of the custom data system. The original system confused the usage of database-backed field (dynamic-fields) and their corresponding implementation. This created the need to crate awkward caching pieces to ensure that validation errors and data was maintained. Furthermore, the system confused the linking between form instances (dynamic-entry) and the form used to represent that entry.

This patch addresses the confusion in two ways:

Dynamic form entries do not link directly to the dynamic form. Instead, the ::getForm() method returns something from the forms API directly. Furthermore, the ::getFields() method does not return dynamic field instances (database backed / designed fields). Instead, the actual implementation of the fields from the forms API is retrieved. This allows the fields to *always* be cached, which helps preserve data and validation state.

Secondly, the dynamic form uses the same system, so that requests to turn a dynamic form into a form (via ::getForm) will also result in the same behavior, again, where the fields are represented as forms API fields rather than the dynamic fields.

So going forward, the dynamic fields are *only* used to create corresponding forms API field implementations. They are associated with the dynamic counterparts as sparingly as possible.