### PR TITLE
mailer: Try harder to find References header

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -304,11 +304,13 @@ class Mailer {
         if (isset($options['thread'])
             && $options['thread'] instanceof ThreadEntry
         ) {
-            $headers += array('References' => $options['thread']->getEmailReferences());
             if ($irt = $options['thread']->getEmailMessageId()) {
                 // This is an response from an email, like and autoresponse.
                 // Web posts will not have a email message-id
-                $headers += array('In-Reply-To' => $irt);
+                $headers += array(
+                    'In-Reply-To' => $irt,
+                    'References' => $options['thread']->getEmailReferences()
+                );
             }
             elseif ($parent = $options['thread']->getParent()) {
                 // Use the parent item as the email information source. This


### PR DESCRIPTION
Ensure that the References header that is included with outbound email definitely includes the References header from an email received into the system, if at all possible.

Maybe Fixes #1346