### PR TITLE
email: Match collaborator by email address too

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -745,7 +745,16 @@ class ThreadEntry {
         if ($mailinfo['userId']
                 || strcasecmp($mailinfo['email'], $ticket->getEmail()) == 0) {
             $vars['message'] = $body;
-            $vars['userId'] = $mailinfo['userId'] ? $mailinfo['userId'] : $ticket->getUserId();
+            $vars['userId'] = $mailinfo['userId'] ?: $ticket->getUserId();
+            return $ticket->postMessage($vars, 'Email');
+        }
+        elseif (($E = UserEmail::lookup($mailinfo['email']))
+            && ($C = Collaborator::lookup(array(
+                'ticketId' => $ticket->getId(), 'userId' => $E->user_id
+            )))
+        ) {
+            $vars['userId'] = $C->getUserId();
+            $vars['message'] = $body;
             return $ticket->postMessage($vars, 'Email');
         }
         // XXX: Consider collaborator role


### PR DESCRIPTION
If a collaborator on a ticket responds to an email NOT originating from osTicket, the system did not consider the replying user's email address. Previously, the system would attempt to identify a collaborator from the tagged Message-ID header (or References header in versions previous to v1.9.6).

This patch will also attempt to match the collaborator by the From email address header, and will post a message to the ticket rather than perhaps falling back to an internal note.