### PR TITLE
Fix ISO codepage

### DIFF
--- a/include/class.charset.php
+++ b/include/class.charset.php
@@ -29,7 +29,7 @@ class Charset {
         // ks_c_5601-1987: Korean alias for cp949
         case preg_match('`^ks_c_5601-1987`', $charset):
             return 'cp949';
-        case preg_match('`^iso-?(\S+)$`', $charset, $match);
+        case preg_match('`^iso-?(\S+)$`', $charset, $match):
             return "ISO-".$match[1];
         // Incorrect, bogus, ambiguous or empty charsets
         // ISO-8859-1 is assumed

--- a/include/class.charset.php
+++ b/include/class.charset.php
@@ -29,6 +29,8 @@ class Charset {
         // ks_c_5601-1987: Korean alias for cp949
         case preg_match('`^ks_c_5601-1987`', $charset):
             return 'cp949';
+        case preg_match('`^iso-?(\S+)$`', $charset, $match);
+            return "ISO-".$match[1];
         // Incorrect, bogus, ambiguous or empty charsets
         // ISO-8859-1 is assumed
         case preg_match('`^(default|x-user-defined|iso|us-ascii)`', $charset):


### PR DESCRIPTION
Fix for issue: Character set issue after upgrading to v1.9.6 or 1.9.7 #1946

https://github.com/osTicket/osTicket-1.8/issues/1946