### PR TITLE
Fix image CID rewrite for some pasted images

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -228,7 +228,7 @@ class Format {
     function localizeInlineImages($text) {
         // Change file.php urls back to content-id's
         return preg_replace(
-            '/src="(?:\/[^"]+?)?\/file\\.php\\?(?:\w+=[^&]+&(?:amp;)?)*?key=([^&]+)[^"]*/',
+            '`src="(?:https?:/)?(?:/[^/"]+)*?/file\\.php\\?(?:\w+=[^&]+&(?:amp;)?)*?key=([^&]+)[^"]*`',
             'src="cid:$1', $text);
     }
 


### PR DESCRIPTION
Copy+Pasting images from a ticket thread or from a FAQ article to the HTML editor and submitting will result in the URL *not* being properly rewritten for storage in the database. When images are uploaded, a relative URL is returned from the server and embedded in the HTML editor. However, when images from the system are copy and pasted into the editor, an absolute URL with the http:// scheme is included. This URL was not properly handled by the URL rewriter in Format::localizeInlineImages().

This patch addresses the issue by properly handling both relative URLs from image uploads and absolute URLs from copy and pasting.

Maybe fixes #334