### PR TITLE
mailer: Embed the Message-Id token in @class

### DIFF
--- a/include/class.format.php
+++ b/include/class.format.php
@@ -219,7 +219,7 @@ class Format {
             'schemes' => 'href: aim, feed, file, ftp, gopher, http, https, irc, mailto, news, nntp, sftp, ssh, telnet; *:file, http, https; src: cid, http, https, data',
             'hook_tag' => function($e, $a=0) { return Format::__html_cleanup($e, $a); },
             'elements' => '*+iframe',
-            'spec' => 'iframe=-*,height,width,type,src(match="`^(https?:)?//(www\.)?(youtube|dailymotion|vimeo)\.com/`i"),frameborder; div=data-mid',
+            'spec' => 'iframe=-*,height,width,type,src(match="`^(https?:)?//(www\.)?(youtube|dailymotion|vimeo)\.com/`i"),frameborder',
         );
 
         return Format::html($html, $config);

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -344,7 +344,7 @@ class Mailer {
         if (!(isset($options['text']) && $options['text'])) {
             if ($reply_tag || $mid_token) {
                 $message = "<div style=\"display:none\"
-                    data-mid=\"$mid_token\">$reply_tag</div>$message";
+                    class=\"mid-$mid_token\">$reply_tag</div>$message";
             }
             $txtbody = rtrim(Format::html2text($message, 90, false))
                 . ($mid_token ? "\nRef-Mid: $mid_token\n" : '');

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -996,7 +996,7 @@ class ThreadEntry {
         }
 
         // Search for the message-id token in the body
-        if (preg_match('`(?:data-mid="|Ref-Mid: )([^"\s]*)(?:$|")`',
+        if (preg_match('`(?:class="mid-|Ref-Mid: )([^"\s]*)(?:$|")`',
                 $mailinfo['message'], $match))
             if ($thread = ThreadEntry::lookupByRefMessageId($match[1],
                     $mailinfo['email']))


### PR DESCRIPTION
Several mail clients do not return the Message-ID header in a In-Reply-To or References header as they should. The assumption by such mail clients is that the email be threaded based on the Subject header. However, osTicket does not require the ticket number to be placed in the Subject header and so has trouble threading email from such systems. osTicket embeds a copy of the Message-ID header (or compatible version) in the body of the message in hopes part of the message will be returned.

Many mail clients (such as osTicket) strip and clean the HTML when processing HTML email. Previously, the message-id token was embedded in a @data-mid attribute, which was likely stripped before the HTML email would be returned back to osTicket.

This patch suggests that the token be placed in a @class attribute, which has a much better chance of returning to osTicket.