### PR TITLE
db: Drop tables before adding and renaming

### DIFF
--- a/include/upgrader/streams/core/435c62c3-2e7531a2.patch.sql
+++ b/include/upgrader/streams/core/435c62c3-2e7531a2.patch.sql
@@ -5,6 +5,7 @@
  */
 
 -- Group department access table
+DROP TABLE IF EXISTS `%TABLE_PREFIX%group_dept_access`;
 CREATE TABLE `%TABLE_PREFIX%group_dept_access` (
   `group_id` int(10) unsigned NOT NULL default '0',
   `dept_id` int(10) unsigned NOT NULL default '0',

--- a/include/upgrader/streams/core/c00511c7-7be60a84.patch.sql
+++ b/include/upgrader/streams/core/c00511c7-7be60a84.patch.sql
@@ -96,6 +96,7 @@ INSERT INTO `%TABLE_PREFIX%sla` (`isactive`, `enable_priority_escalation`,
     VALUES (1, 1, 0, 48, 'Default SLA', NULL, NOW(), NOW());
 
 -- Create a TEAM table
+DROP TABLE IF EXISTS `%TABLE_PREFIX%team`;
 CREATE TABLE IF NOT EXISTS `%TABLE_PREFIX%team` (
     `team_id` int(10) unsigned NOT NULL auto_increment,
     `lead_id` int(10) unsigned NOT NULL default '0',
@@ -282,6 +283,7 @@ ALTER TABLE `%TABLE_PREFIX%kb_premade`
   ADD `notes` TEXT NOT NULL AFTER `response`,
   DROP INDEX `title`;
 
+DROP TABLE IF EXISTS `%TABLE_PREFIX%canned_response`;
 ALTER TABLE `%TABLE_PREFIX%kb_premade` RENAME TO `%TABLE_PREFIX%canned_response`;
 
 DROP TABLE IF EXISTS `%TABLE_PREFIX%faq_category`;

--- a/include/upgrader/streams/core/d0e37dca-1da1bcba.patch.sql
+++ b/include/upgrader/streams/core/d0e37dca-1da1bcba.patch.sql
@@ -3,16 +3,18 @@
  * @signature 1da1bcbafcedc65efef58f142a48ac91
  *
  *  Upgrade from 1.6 RC3 + filters
- *  
+ *
  */
 
+DROP TABLE IF EXISTS `%TABLE_PREFIX%filter`;
 RENAME TABLE  `%TABLE_PREFIX%email_filter` TO  `%TABLE_PREFIX%filter`;
 
+DROP TABLE IF EXISTS `%TABLE_PREFIX%filter_rule`;
 RENAME TABLE  `%TABLE_PREFIX%email_filter_rule` TO  `%TABLE_PREFIX%filter_rule`;
 
 ALTER TABLE  `%TABLE_PREFIX%filter` CHANGE  `reject_email`  `reject_ticket` TINYINT( 1 ) UNSIGNED NOT NULL DEFAULT  '0';
 
-ALTER TABLE  `%TABLE_PREFIX%filter` 
+ALTER TABLE  `%TABLE_PREFIX%filter`
     ADD  `target` ENUM(  'Any',  'Web',  'Email',  'API' ) NOT NULL DEFAULT  'Any' AFTER  `sla_id` ,
     ADD INDEX (  `target` );
 


### PR DESCRIPTION
If osTicket was improperly or incompletely upgraded, then some tables may exist which should otherwise not exist. This patch assists the upgrade process by dropping the tables which should not exist prior to adding or renaming tables.