### PR TITLE
html: Ensure text internal note preserved

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2932,6 +2932,9 @@ class Ticket {
 
         // Not assigned...save optional note if any
         if (!$vars['assignId'] && $vars['note']) {
+            if (!$cfg->isHtmlThreadEnabled()) {
+                $vars['note'] = new TextThreadBody($vars['note']);
+            }
             $ticket->logNote(_S('New Ticket'), $vars['note'], $thisstaff, false);
         }
         else {


### PR DESCRIPTION
Preserve text formatting on the internal note posted to a new ticket by staff if HTML thread is disabled.