### PR TITLE
Fix for staff submitting ticket by email

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -993,14 +993,19 @@ class ThreadEntry {
                 //Lookup by ticket number
                 && ($ticket = Ticket::lookupByNumber($match[1]))
                 //Lookup the user using the email address
-                && ($user = User::lookup(array('emails__address' => $mailinfo['email'])))) {
+                && ($user = User::lookup(array('emails__address' => $mailinfo['email'])))
+                && ($staff = Staff::getIdByEmail($mailinfo['email']))) {
             //We have a valid ticket and user
-            if ($ticket->getUserId() == $user->getId() //owner
+            if (!empty($staff) || $ticket->getUserId() == $user->getId() //owner
                     ||  ($c = Collaborator::lookup( // check if collaborator
                             array('userId' => $user->getId(),
                                   'ticketId' => $ticket->getId())))) {
 
-                $mailinfo['userId'] = $user->getId();
+                if (empty($staff))
+	                $mailinfo['userId'] = $user->getId();
+                else
+	                $mailinfo['staffId'] = $staff;
+	                
                 return $ticket->getLastMessage();
             }
         }


### PR DESCRIPTION
I noticed there is a bug when class.thread.php has to fall back to the ticket number in the subject line.  If the user is a staff member and they send a note to a ticket via email without including the existing thread (just the ticket number), it will create a new ticket because the fall back logic does not account for staff...  This fix would correct that

Tested locally