### PR TITLE
validator: Verify MX record of email addresses

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -718,7 +718,7 @@ class TextboxField extends FormField {
         $config = $this->getConfiguration();
         $validators = array(
             '' =>       null,
-            'email' =>  array(array('Validator', 'is_email'),
+            'email' =>  array(array('Validator', 'is_valid_email'),
                 __('Enter a valid email address')),
             'phone' =>  array(array('Validator', 'is_phone'),
                 __('Enter a valid phone number')),

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -454,7 +454,7 @@ implements EmailContact {
         if(!$vars['lastname'])
             $errors['lastname']=__('Last name is required');
 
-        if(!$vars['email'] || !Validator::is_email($vars['email']))
+        if(!$vars['email'] || !Validator::is_valid_email($vars['email']))
             $errors['email']=__('Valid email is required');
         elseif(Email::getIdByEmail($vars['email']))
             $errors['email']=__('Already in-use as system email');

--- a/include/class.validator.php
+++ b/include/class.validator.php
@@ -140,7 +140,7 @@ class Validator {
 
     /*** Functions below can be called directly without class instance.
          Validator::func(var..);  (nolint) ***/
-    function is_email($email, $list=false) {
+    function is_email($email, $list=false, $verify=false) {
         require_once PEAR_DIR . 'Mail/RFC822.php';
         require_once PEAR_DIR . 'PEAR.php';
         if (!($mails = Mail_RFC822::parseAddressList($email)) || PEAR::isError($mails))
@@ -156,8 +156,16 @@ class Validator {
                 return false;
         }
 
+        if ($verify && !checkdnsrr($m->host, 'MX'))
+            return false;
+
         return true;
     }
+
+    function is_valid_email($email) {
+        return self::is_email($email, false, true);
+    }
+
     function is_phone($phone) {
         /* We're not really validating the phone number but just making sure it doesn't contain illegal chars and of acceptable len */
         $stripped=preg_replace("(\(|\)|\-|\.|\+|[  ]+)","",$phone);

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -42,6 +42,8 @@ if (!$errors['err']) {
                 $lock->getStaffName());
     elseif (($emailBanned=TicketFilter::isBanned($ticket->getEmail())))
         $errors['err'] = __('Email is in banlist! Must be removed before any reply/response');
+    elseif (!Validator::is_valid_email($ticket->getEmail()))
+        $errors['err'] = __('EndUser email address is not valid! Consider updating it before responding');
 }
 
 $unbannable=($emailBanned) ? BanList::includes($ticket->getEmail()) : false;

--- a/scp/banlist.php
+++ b/scp/banlist.php
@@ -33,7 +33,7 @@ if($_POST && !$errors && $filter){
         case 'update':
             if(!$rule){
                 $errors['err']=sprintf(__('%s: Unknown or invalid'), __('ban rule'));
-            }elseif(!$_POST['val'] || !Validator::is_email($_POST['val'])){
+            }elseif(!$_POST['val'] || !Validator::is_valid_email($_POST['val'])){
                 $errors['err']=$errors['val']=__('Valid email address required');
             }elseif(!$errors){
                 $vars=array('what'=>'email',
@@ -52,7 +52,7 @@ if($_POST && !$errors && $filter){
         case 'add':
             if(!$filter) {
                 $errors['err']=sprintf(__('%s: Unknown or invalid'), __('ban list'));
-            }elseif(!$_POST['val'] || !Validator::is_email($_POST['val'])) {
+            }elseif(!$_POST['val'] || !Validator::is_valid_email($_POST['val'])) {
                 $errors['err']=$errors['val']=__('Valid email address required');
             }elseif(BanList::includes(trim($_POST['val']))) {
                 $errors['err']=$errors['val']=__('Email already in the ban list');

--- a/scp/banlist.php
+++ b/scp/banlist.php
@@ -33,7 +33,7 @@ if($_POST && !$errors && $filter){
         case 'update':
             if(!$rule){
                 $errors['err']=sprintf(__('%s: Unknown or invalid'), __('ban rule'));
-            }elseif(!$_POST['val'] || !Validator::is_valid_email($_POST['val'])){
+            }elseif(!$_POST['val'] || !Validator::is_email($_POST['val'])){
                 $errors['err']=$errors['val']=__('Valid email address required');
             }elseif(!$errors){
                 $vars=array('what'=>'email',
@@ -52,7 +52,7 @@ if($_POST && !$errors && $filter){
         case 'add':
             if(!$filter) {
                 $errors['err']=sprintf(__('%s: Unknown or invalid'), __('ban list'));
-            }elseif(!$_POST['val'] || !Validator::is_valid_email($_POST['val'])) {
+            }elseif(!$_POST['val'] || !Validator::is_email($_POST['val'])) {
                 $errors['err']=$errors['val']=__('Valid email address required');
             }elseif(BanList::includes(trim($_POST['val']))) {
                 $errors['err']=$errors['val']=__('Email already in the ban list');

--- a/scp/emailtest.php
+++ b/scp/emailtest.php
@@ -25,8 +25,8 @@ if($_POST){
     if(!$_POST['email_id'] || !($email=Email::lookup($_POST['email_id'])))
         $errors['email_id']=__('Select from email address');
 
-    if(!$_POST['email'] || !Validator::is_email($_POST['email']))
-        $errors['email']=__('To email address required');
+    if(!$_POST['email'] || !Validator::is_valid_email($_POST['email']))
+        $errors['email']=__('Valid recipient email address required');
 
     if(!$_POST['subj'])
         $errors['subj']=__('Subject required');

--- a/setup/install.php
+++ b/setup/install.php
@@ -65,7 +65,7 @@ if($_POST && $_POST['s']) {
 
             if(!$_POST['email'])
                 $errors['email'] = __('Required');
-            elseif(!Validator::is_email($_POST['email']))
+            elseif(!Validator::is_valid_email($_POST['email']))
                 $errors['email'] = __('Invalid');
 
             if(!$_POST['alerts'] && !$_POST['news'])


### PR DESCRIPTION
This allows detection of some incorrectly-typed email addresses before tickets, users, and agents are created.

It also adds a warning to the ticket view page to alert agents of invalid, in-use email addresses. This may happen for emails processed into tickets when the `Reply-To` header is used, as well as for old tickets created before this patch.