### PR TITLE
when opening a ticket, no longer auto-scrolls to the bottom or Reply box

### DIFF
--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -37,7 +37,10 @@ function checkbox_checker(formObj, min, max) {
 
 var scp_prep = function() {
 
-    $("input:not(.dp):visible:enabled:first").focus();
+    var id = getURLTicketVars()["id"];
+    var a = getURLTicketVars()["a"];
+    if(getPage() != "tickets.php" || (id == null || a != null)) 
+            $("input:not(.dp):visible:enabled:first").focus();
     $('table.list input:checkbox').bind('click, change', function() {
         $(this)
             .parents("tr:first")
@@ -850,4 +853,15 @@ function __(s) {
   if ($.oststrings && $.oststrings[s])
     return $.oststrings[s];
   return s;
+}
+function getURLTicketVars() {
+    var vars = {};
+    var parts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m,key,value) {
+        vars[key] = value;
+    });
+    return vars;
+}
+function getPage() {
+	var sPath=window.location.pathname;
+	return sPath.substring(sPath.lastIndexOf('/') + 1);
 }


### PR DESCRIPTION
This fix resolves the issue of when you open a ticket, it scrolls to the bottom of the page.

It also keeps from breaking all the other pages that use the focus functionality (exs. the main staff tickets screen to auto-focus on the search box, the ticket edit screen).