### PR TITLE
Requiring auth to fix Fatal error

### DIFF
--- a/include/class.client.php
+++ b/include/class.client.php
@@ -14,6 +14,7 @@
     vim: expandtab sw=4 ts=4 sts=4:
 **********************************************************************/
 require_once INCLUDE_DIR.'class.user.php';
+require_once INCLUDE_DIR.'class.auth.php';
 
 abstract class TicketUser
 implements EmailContact {


### PR DESCRIPTION
Related to https://github.com/osTicket/osTicket-1.8/pull/2092#issuecomment-104012105

```
[23-Apr-2015 12:28:08 America/Chicago] PHP Fatal error:  Class 'AuthenticatedUser' not found in support/include/class.client.php on line 190
[23-Apr-2015 12:28:08 America/Chicago] PHP Stack trace:
[23-Apr-2015 12:28:08 America/Chicago] PHP   1. {main}() support/open.php:0
[23-Apr-2015 12:28:08 America/Chicago] PHP   2. require() support/open.php:5
[23-Apr-2015 12:28:08 America/Chicago] PHP   3. require_once() support/client.inc.php:21
[23-Apr-2015 12:28:08 America/Chicago] PHP   4. require() support/main.inc.php:124
[23-Apr-2015 12:28:08 America/Chicago] PHP   5. include_once() support/include/class.usersession.php:17                                                                                                                                                                                     ```