### PR TITLE
search: Fix several small issues with search indexing

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -606,6 +606,8 @@ class MysqlSearchBackend extends SearchBackend {
         // FILES ------------------------------------
 
         // Flush non-full batch of records
+        $this->__index(null, true);
+
         if (!$this->_reindexed) {
             // Stop rebuilding the index
             $this->getConfig()->set('reindex', 0);


### PR DESCRIPTION
* Reindexing did not properly flush the last batch of items to the search therefore reindexing would always miss the last few items.
* Creating a new html thread entry with inline images resulted in empty search content
* HTML tag stripping in HtmlThreadBody::getSearchable() would result in missing white space between some words, resulting in poor searchable content