### PR TITLE
forms: Fix fail getting value of password field

### DIFF
--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1794,7 +1794,7 @@ class PasswordWidget extends TextboxWidget {
         parent::parseValue();
         // Show empty box unless failed POST
         if ($_SERVER['REQUEST_METHOD'] != 'POST'
-                || $this->field->getForm()->isValid())
+                || !$this->field->getForm()->isValid())
             $this->value = '';
     }
 }


### PR DESCRIPTION
This fixes the inability to save the search user password in the LDAP or S3 plugins