### PR TITLE
Handle special characters in user/staff name

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -239,7 +239,7 @@ class Mailer {
             // Add personal name if available
             if (is_callable(array($to, 'getName'))) {
                 $to = sprintf('"%s" <%s>',
-                    $to->getName()->getOriginal(), $to->getEmail()
+                    "=?UTF-8?B?".base64_encode($to->getName()->getOriginal())."?=", $to->getEmail()
                 );
             }
             else {


### PR DESCRIPTION
for user/staff name with special characters, email notification are never sent (at least with php mail function) because the name is not encoded. This change adds encoding of the staff/user name in the "to" field of the email to be sent