### PR TITLE
Prevent mail fetch failure

### DIFF
--- a/include/class.mailfetch.php
+++ b/include/class.mailfetch.php
@@ -265,7 +265,7 @@ class MailFetcher {
 
     function getHeaderInfo($mid) {
 
-        if(!($headerinfo=imap_headerinfo($this->mbox, $mid)) || !$headerinfo->from)
+        if(!($headerinfo=imap_rfc822_parse_headers(imap_fetchheader($this->mbox, $mid))) || !$headerinfo->from)
             return null;
 
         $raw_header = $this->getHeader($mid);


### PR DESCRIPTION
For some incoming emails, the php function imap_headerinfo just fails to get the headers right, an example can be found below (see also http://php.net/manual/fr/function.imap-headerinfo.php#98809). Using imap_rfc822_parse_headers(imap_fetchheader()) corrects this

Return-Path: <>
Delivery-Date: Fri, 11 Apr 2014 03:27:57 +0100
Received: from spamreport by localhost id ******-********-**** for
 support@*****.com (mailbox m******-*****);
 Fri, 11 Apr 2014 03:27:57 +0100
From: =?utf-8?q?D=C3=A9tection_de_spam_=3Cnoreply=401and1=2Efr=3E?=
Subject: Rapport quotidien du dossier Spam du compte email
 support@*****.com
Date: Fri, 11 Apr 2014 03:27:57 +0100
To: <support@*****.com>
Message-Id: <******-******-****@spamreport.1and1.fr>
Envelope-To: support@*******.com
MIME-Version: 1.0
Content-Type: text/plain; charset="utf-8"
Content-Transfer-Encoding: quoted-printable

Votre dossier Spam contient 1 nouveau message.

Les messages contenus dans ce dossier seront automatiquement
supprim=C3=A9s dans 28 jour(s).