### PR TITLE
log php mail error

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -514,7 +514,8 @@ class Mailer {
             // Force reconnect on next ->send()
             unset($smtp_connections[$key]);
 
-            $alert=sprintf(_S("Unable to email via SMTP:%1\$s:%2\$d [%3\$s]\n\n%4\$s\n"),
+            $alert=_S("Unable to email via SMTP")
+                    .sprintf(":%1\$s:%2\$d [%3\$s]\n\n%4\$s\n",
                     $smtp['host'], $smtp['port'], $smtp['username'], $result->getMessage());
             $this->logError($alert);
         }
@@ -527,7 +528,8 @@ class Mailer {
         if(!PEAR::isError($result))
             return $messageId;
 
-        $alert=sprintf(_S("Unable to email via php mail function:%1\$s\n\n%2\$s\n"),
+        $alert=_S("Unable to email via php mail function")
+                .sprintf(":%1\$s\n\n%2\$s\n",
                 $to, $result->getMessage());
         $this->logError($alert);
         return false;

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -523,8 +523,14 @@ class Mailer {
         $mail = mail::factory('mail');
         // Ensure the To: header is properly encoded.
         $to = $headers['To'];
-        return PEAR::isError($mail->send($to, $headers, $body))?false:$messageId;
+        $result = $mail->send($to, $headers, $body);
+        if(!PEAR::isError($result))
+            return $messageId;
 
+        $alert=sprintf(__("Unable to email via php mail function:%1\$s\n\n%2\$s\n"),
+                $to, $result->getMessage());
+        $this->logError($alert);
+        return false;
     }
 
     function logError($error) {

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -514,7 +514,7 @@ class Mailer {
             // Force reconnect on next ->send()
             unset($smtp_connections[$key]);
 
-            $alert=sprintf(__("Unable to email via SMTP:%1\$s:%2\$d [%3\$s]\n\n%4\$s\n"),
+            $alert=sprintf(_S("Unable to email via SMTP:%1\$s:%2\$d [%3\$s]\n\n%4\$s\n"),
                     $smtp['host'], $smtp['port'], $smtp['username'], $result->getMessage());
             $this->logError($alert);
         }
@@ -527,7 +527,7 @@ class Mailer {
         if(!PEAR::isError($result))
             return $messageId;
 
-        $alert=sprintf(__("Unable to email via php mail function:%1\$s\n\n%2\$s\n"),
+        $alert=sprintf(_S("Unable to email via php mail function:%1\$s\n\n%2\$s\n"),
                 $to, $result->getMessage());
         $this->logError($alert);
         return false;
@@ -536,7 +536,7 @@ class Mailer {
     function logError($error) {
         global $ost;
         //NOTE: Admin alert override - don't email when having email trouble!
-        $ost->logError(__('Mailer Error'), $error, false);
+        $ost->logError(_S('Mailer Error'), $error, false);
     }
 
     /******* Static functions ************/


### PR DESCRIPTION
When the php mail function is used to send email, this change adds error logging if an error is detected by PEAR