### PR TITLE
Advanced search was killing my MySQL 

### DIFF
--- a/ajax.reports.php
+++ b/ajax.reports.php
@@ -1,0 +1,239 @@
+<?php
+/*********************************************************************
+    ajax.reports.php
+
+    AJAX interface for reports -- both plot and tabular data are retrievable
+    in JSON format from this utility. Please put plumbing in /scp/ajax.php
+    pattern rules.
+
+    Jared Hancock <jared@osticket.com>
+    Copyright (c)  2006-2013 osTicket
+    http://www.osticket.com
+
+    Released under the GNU General Public License WITHOUT ANY WARRANTY.
+    See LICENSE.TXT for details.
+
+    vim: expandtab sw=4 ts=4 sts=4:
+**********************************************************************/
+
+if(!defined('INCLUDE_DIR')) die('403');
+
+include_once(INCLUDE_DIR.'class.ticket.php');
+
+/**
+ * Overview Report
+ *
+ * The overview report allows for the display of basic ticket statistics in
+ * both graphical and tabular formats.
+ */
+class OverviewReportAjaxAPI extends AjaxController {
+    function enumTabularGroups() {
+        return $this->encode(array("dept"=>__("Department"), "topic"=>__("Topics"),
+            # XXX: This will be relative to permissions based on the
+            # logged-in-staff. For basic staff, this will be 'My Stats'
+            "staff"=>__("Agent")));
+    }
+
+    function getData() {
+        global $thisstaff;
+
+        list($start, $stop) = $this->_getDateRange();
+
+        $groups = array(
+            "dept" => array(
+                "table" => DEPT_TABLE,
+                "pk" => "dept_id",
+                "sort" => 'T1.dept_name',
+                "fields" => 'T1.dept_name',
+                "headers" => array(__('Department')),
+                "filter" => ('T1.dept_id IN ('.implode(',', db_input($thisstaff->getDepts())).')')
+            ),
+            "topic" => array(
+                "table" => TOPIC_TABLE,
+                "pk" => "topic_id",
+                "sort" => 'name',
+                "fields" => "CONCAT_WS(' / ',"
+                    ."(SELECT P.topic FROM ".TOPIC_TABLE." P WHERE P.topic_id = T1.topic_pid),"
+                    ."T1.topic) as name ",
+                "headers" => array(__('Help Topic')),
+                "filter" => '1'
+            ),
+            "staff" => array(
+                "table" => STAFF_TABLE,
+                "pk" => 'staff_id',
+                "sort" => 'name',
+                "fields" => "CONCAT_WS(' ', T1.firstname, T1.lastname) as name",
+                "headers" => array(__('Agent')),
+                "filter" =>
+                    ('T1.staff_id=S1.staff_id
+                      AND
+                      (T1.staff_id='.db_input($thisstaff->getId())
+                        .(($depts=$thisstaff->getManagedDepartments())?
+                            (' OR T1.dept_id IN('.implode(',', db_input($depts)).')'):'')
+                        .(($thisstaff->canViewStaffStats())?
+                            (' OR T1.dept_id IN('.implode(',', db_input($thisstaff->getDepts())).')'):'')
+                     .')'
+                     )
+            )
+        );
+        $group = $this->get('group', 'dept');
+        $info = isset($groups[$group])?$groups[$group]:$groups['dept'];
+
+        # XXX: Die if $group not in $groups
+
+        $queries=array(
+            array(5, 'SELECT '.$info['fields'].',
+                COUNT(*)-COUNT(NULLIF(A1.state, "created")) AS Opened,
+                COUNT(*)-COUNT(NULLIF(A1.state, "assigned")) AS Assigned,
+                COUNT(*)-COUNT(NULLIF(A1.state, "overdue")) AS Overdue,
+                COUNT(*)-COUNT(NULLIF(A1.state, "closed")) AS Closed,
+                COUNT(*)-COUNT(NULLIF(A1.state, "reopened")) AS Reopened
+            FROM '.$info['table'].' T1
+                LEFT JOIN '.TICKET_EVENT_TABLE.' A1
+                    ON (A1.'.$info['pk'].'=T1.'.$info['pk'].'
+                         AND NOT annulled
+                         AND (A1.timestamp BETWEEN '.$start.' AND '.$stop.'))
+                LEFT JOIN '.STAFF_TABLE.' S1 ON (S1.staff_id=A1.staff_id)
+            WHERE '.$info['filter'].'
+            GROUP BY T1.'.$info['pk'].'
+            ORDER BY '.$info['sort']),
+
+            array(1, 'SELECT '.$info['fields'].',
+                FORMAT(AVG(DATEDIFF(T2.closed, T2.created)),1) AS ServiceTime
+            FROM '.$info['table'].' T1
+                LEFT JOIN '.TICKET_TABLE.' T2 ON (T2.'.$info['pk'].'=T1.'.$info['pk'].')
+                LEFT JOIN '.STAFF_TABLE.' S1 ON (S1.staff_id=T2.staff_id)
+            WHERE '.$info['filter'].' AND T2.closed BETWEEN '.$start.' AND '.$stop.'
+            GROUP BY T1.'.$info['pk'].'
+            ORDER BY '.$info['sort']),
+
+            array(1, 'SELECT '.$info['fields'].',
+                FORMAT(AVG(DATEDIFF(B2.created, B1.created)),1) AS ResponseTime
+            FROM '.$info['table'].' T1
+                LEFT JOIN '.TICKET_TABLE.' T2 ON (T2.'.$info['pk'].'=T1.'.$info['pk'].')
+                LEFT JOIN '.TICKET_THREAD_TABLE.' B2 ON (B2.ticket_id = T2.ticket_id
+                    AND B2.thread_type="R")
+                LEFT JOIN '.TICKET_THREAD_TABLE.' B1 ON (B2.pid = B1.id)
+                LEFT JOIN '.STAFF_TABLE.' S1 ON (S1.staff_id=B2.staff_id)
+            WHERE '.$info['filter'].' AND B1.created BETWEEN '.$start.' AND '.$stop.'
+            GROUP BY T1.'.$info['pk'].'
+            ORDER BY '.$info['sort'])
+        );
+        $rows = array();
+        $cols = 1;
+        foreach ($queries as $q) {
+            list($c, $sql) = $q;
+            $res = db_query($sql);
+            $cols += $c;
+            while ($row = db_fetch_row($res)) {
+                $found = false;
+                foreach ($rows as &$r) {
+                    if ($r[0] == $row[0]) {
+                        $r = array_merge($r, array_slice($row, -$c));
+                        $found = true;
+                        break;
+                    }
+                }
+                if (!$found)
+                    $rows[] = array_merge(array($row[0]), array_slice($row, -$c));
+            }
+            # Make sure each row has the same number of items
+            foreach ($rows as &$r)
+                while (count($r) < $cols)
+                    $r[] = null;
+        }
+        return array("columns" => array_merge($info['headers'],
+                        array(__('Opened'),__('Assigned'),__('Overdue'),__('Closed'),__('Reopened'),
+                              __('Service Time'),__('Response Time'))),
+                     "data" => $rows);
+    }
+
+    function getTabularData() {
+        return $this->encode($this->getData());
+    }
+
+    function downloadTabularData() {
+        $data = $this->getData();
+        $csv = '"' . implode('","',$data['columns']) . '"';
+        foreach ($data['data'] as $row)
+            $csv .= "\n" . '"' . implode('","', $row) . '"';
+        Http::download(
+            sprintf('%s-report.csv', $this->get('group', __('Department'))),
+            'text/csv', $csv);
+    }
+
+    function _getDateRange() {
+        global $cfg;
+
+        if(($start = $this->get('start', 'last month'))) {
+            $stop = $this->get('period', 'now');
+        } else {
+            $start = 'last month';
+            $stop = $this->get('period', 'now');
+        }
+
+        if ($start != 'last month')
+            $start = DateTime::createFromFormat($cfg->getDateFormat(),
+                $start)->format('U');
+        else
+            $start = strtotime($start);
+
+        if (substr($stop, 0, 1) == '+')
+            $stop = strftime('%Y-%m-%d ', $start) . $stop;
+
+        $start = 'FROM_UNIXTIME('.$start.')';
+        $stop = 'FROM_UNIXTIME('.strtotime($stop).')';
+
+        return array($start, $stop);
+    }
+
+    function getPlotData() {
+        list($start, $stop) = $this->_getDateRange();
+
+        # Fetch all types of events over the timeframe
+        $res = db_query('SELECT DISTINCT(state) FROM '.TICKET_EVENT_TABLE
+            .' WHERE timestamp BETWEEN '.$start.' AND '.$stop
+                .' ORDER BY 1');
+        $events = array();
+        while ($row = db_fetch_row($res)) $events[] = $row[0];
+
+        # TODO: Handle user => db timezone offset
+        # XXX: Implement annulled column from the %ticket_event table
+        $res = db_query('SELECT state, DATE_FORMAT(timestamp, \'%Y-%m-%d\'), '
+                .'COUNT(ticket_id)'
+            .' FROM '.TICKET_EVENT_TABLE
+            .' WHERE timestamp BETWEEN '.$start.' AND '.$stop
+            .' AND NOT annulled'
+            .' GROUP BY state, DATE_FORMAT(timestamp, \'%Y-%m-%d\')'
+            .' ORDER BY 2, 1');
+        # Initialize array of plot values
+        $plots = array();
+        foreach ($events as $e) { $plots[$e] = array(); }
+
+        $time = null; $times = array();
+        # Iterate over result set, adding zeros for missing ticket events
+        $slots = array();
+        while ($row = db_fetch_row($res)) {
+            $row_time = strtotime($row[1]);
+            if ($time != $row_time) {
+                # New time (and not the first), figure out which events did
+                # not have any tickets associated for this time slot
+                if ($time !== null) {
+                    # Not the first record -- add zeros all the arrays that
+                    # did not have at least one entry for the timeframe
+                    foreach (array_diff($events, $slots) as $slot)
+                        $plots[$slot][] = 0;
+                }
+                $slots = array();
+                $times[] = $time = $row_time;
+            }
+            # Keep track of states for this timeframe
+            $slots[] = $row[0];
+            $plots[$row[0]][] = (int)$row[2];
+        }
+        foreach (array_diff($events, $slots) as $slot)
+            $plots[$slot][] = 0;
+        return $this->encode(array("times" => $times, "plots" => $plots,
+            "events"=>$events));
+    }
+}

--- a/ajax.tickets.php
+++ b/ajax.tickets.php
@@ -1,0 +1,1033 @@
+<?php
+/*********************************************************************
+    ajax.tickets.php
+
+    AJAX interface for tickets
+
+    Peter Rotich <peter@osticket.com>
+    Copyright (c)  2006-2013 osTicket
+    http://www.osticket.com
+
+    Released under the GNU General Public License WITHOUT ANY WARRANTY.
+    See LICENSE.TXT for details.
+
+    vim: expandtab sw=4 ts=4 sts=4:
+**********************************************************************/
+
+if(!defined('INCLUDE_DIR')) die('403');
+
+include_once(INCLUDE_DIR.'class.ticket.php');
+require_once(INCLUDE_DIR.'class.ajax.php');
+require_once(INCLUDE_DIR.'class.note.php');
+
+class TicketsAjaxAPI extends AjaxController {
+
+    function lookup() {
+        global $thisstaff;
+
+        if(!is_numeric($_REQUEST['q']))
+            return self::lookupByEmail();
+
+
+        $limit = isset($_REQUEST['limit']) ? (int) $_REQUEST['limit']:25;
+        $tickets=array();
+
+        $sql='SELECT DISTINCT `number`, email.address AS email'
+            .' FROM '.TICKET_TABLE.' ticket'
+            .' LEFT JOIN '.USER_TABLE.' user ON user.id = ticket.user_id'
+            .' LEFT JOIN '.USER_EMAIL_TABLE.' email ON user.id = email.user_id'
+            .' WHERE `number` LIKE \''.db_input($_REQUEST['q'], false).'%\'';
+
+        $sql.=' AND ( staff_id='.db_input($thisstaff->getId());
+
+        if(($teams=$thisstaff->getTeams()) && count(array_filter($teams)))
+            $sql.=' OR team_id IN('.implode(',', db_input(array_filter($teams))).')';
+
+        if(!$thisstaff->showAssignedOnly() && ($depts=$thisstaff->getDepts()))
+            $sql.=' OR dept_id IN ('.implode(',', db_input($depts)).')';
+
+        $sql.=' )  '
+            .' ORDER BY ticket.created LIMIT '.$limit;
+
+        if(($res=db_query($sql)) && db_num_rows($res)) {
+            while(list($id, $email)=db_fetch_row($res)) {
+                $info = "$id - $email";
+                $tickets[] = array('id'=>$id, 'email'=>$email, 'value'=>$id,
+                    'info'=>$info, 'matches'=>$_REQUEST['q']);
+            }
+        }
+        if (!$tickets)
+            return self::lookupByEmail();
+
+        return $this->json_encode($tickets);
+    }
+
+    function lookupByEmail() {
+        global $thisstaff;
+
+
+        $limit = isset($_REQUEST['limit']) ? (int) $_REQUEST['limit']:25;
+        $tickets=array();
+
+        $sql='SELECT email.address AS email, count(ticket.ticket_id) as tickets '
+            .' FROM '.TICKET_TABLE.' ticket'
+            .' JOIN '.USER_TABLE.' user ON user.id = ticket.user_id'
+            .' JOIN '.USER_EMAIL_TABLE.' email ON user.id = email.user_id'
+            .' WHERE (email.address LIKE \'%'.db_input(strtolower($_REQUEST['q']), false).'%\'
+                OR user.name LIKE \'%'.db_input($_REQUEST['q'], false).'%\')';
+
+        $sql.=' AND ( staff_id='.db_input($thisstaff->getId());
+
+        if(($teams=$thisstaff->getTeams()) && count(array_filter($teams)))
+            $sql.=' OR team_id IN('.implode(',', db_input(array_filter($teams))).')';
+
+        if(!$thisstaff->showAssignedOnly() && ($depts=$thisstaff->getDepts()))
+            $sql.=' OR dept_id IN ('.implode(',', db_input($depts)).')';
+
+        $sql.=' ) '
+            .' GROUP BY email.address '
+            .' ORDER BY ticket.created  LIMIT '.$limit;
+
+        if(($res=db_query($sql)) && db_num_rows($res)) {
+            while(list($email, $count)=db_fetch_row($res))
+                $tickets[] = array('email'=>$email, 'value'=>$email,
+                    'info'=>"$email ($count)", 'matches'=>$_REQUEST['q']);
+        }
+
+        return $this->json_encode($tickets);
+    }
+
+    function _search($req) {
+        global $thisstaff, $cfg, $ost;
+
+        $result=array();
+        $criteria = array();
+
+        $select = 'SELECT ticket.ticket_id';
+        $from = ' FROM '.TICKET_TABLE.' ticket
+                  LEFT JOIN '.TICKET_STATUS_TABLE.' status
+                    ON (status.id = ticket.status_id) ';
+        //Access control.
+        $where = ' WHERE ( (ticket.staff_id='.db_input($thisstaff->getId())
+                    .' AND status.state="open" )';
+
+        if(($teams=$thisstaff->getTeams()) && count(array_filter($teams)))
+            $where.=' OR (ticket.team_id IN ('.implode(',', db_input(array_filter($teams)))
+                   .' ) AND status.state="open" )';
+
+        if(!$thisstaff->showAssignedOnly() && ($depts=$thisstaff->getDepts()))
+            $where.=' OR ticket.dept_id IN ('.implode(',', db_input($depts)).')';
+
+        $where.=' ) ';
+
+        //Department
+        if ($req['deptId']) {
+            $where.=' AND ticket.dept_id='.db_input($req['deptId']);
+            $criteria['dept_id'] = $req['deptId'];
+        }
+
+        //Help topic
+        if($req['topicId']) {
+            $where.=' AND ticket.topic_id='.db_input($req['topicId']);
+            $criteria['topic_id'] = $req['topicId'];
+        }
+
+        // Status
+        if ($req['statusId']
+                && ($status=TicketStatus::lookup($req['statusId']))) {
+            $where .= sprintf(' AND status.id="%d" ',
+                    $status->getId());
+            $criteria['status_id'] = $status->getId();
+        }
+
+        // Flags
+        if ($req['flag']) {
+            switch (strtolower($req['flag'])) {
+                case 'answered':
+                    $where .= ' AND ticket.isanswered =1 ';
+                    $criteria['isanswered'] = 1;
+                    $criteria['state'] = 'open';
+                    $where .= ' AND status.state="open" ';
+                    break;
+                case 'overdue':
+                    $where .= ' AND ticket.isoverdue =1 ';
+                    $criteria['isoverdue'] = 1;
+                    $criteria['state'] = 'open';
+                    $where .= ' AND status.state="open" ';
+                    break;
+            }
+        }
+
+        //Assignee
+        if($req['assignee'] && strcasecmp($req['status'], 'closed'))  { # assigned-to
+            $id=preg_replace("/[^0-9]/", "", $req['assignee']);
+            $assignee = $req['assignee'];
+            $where.= ' AND ( ( status.state="open" ';
+            if($assignee[0]=='t') {
+                $where.=' AND ticket.team_id='.db_input($id);
+                $criteria['team_id'] = $id;
+            }
+            elseif($assignee[0]=='s' || is_numeric($id)) {
+                $where.=' AND ticket.staff_id='.db_input($id);
+                $criteria['staff_id'] = $id;
+            }
+
+            $where.=')';
+
+            if($req['staffId'] && !$req['status']) //Assigned TO + Closed By
+                $where.= ' OR (ticket.staff_id='.db_input($req['staffId']).
+                    ' AND status.state IN("closed")) ';
+            elseif($req['staffId']) // closed by any
+                $where.= ' OR status.state IN("closed") ';
+
+            $where.= ' ) ';
+        } elseif($req['staffId']) { # closed-by
+            $where.=' AND (ticket.staff_id='.db_input($req['staffId']).' AND
+                status.state IN("closed")) ';
+            $criteria['state__in'] = array('closed');
+            $criteria['staff_id'] = $req['staffId'];
+        }
+
+        //dates
+        $startTime  =($req['startDate'] && (strlen($req['startDate'])>=8))?strtotime($req['startDate']):0;
+        $endTime    =($req['endDate'] && (strlen($req['endDate'])>=8))?strtotime($req['endDate']):0;
+        if ($endTime)
+            // $endTime should be the last second of the day, not the first like $startTime
+            $endTime += (60 * 60 * 24) - 1;
+        if( ($startTime && $startTime>time()) or ($startTime>$endTime && $endTime>0))
+            $startTime=$endTime=0;
+
+        if($startTime) {
+            $where.=' AND ticket.created>=FROM_UNIXTIME('.$startTime.')';
+            $criteria['created__gte'] = $startTime;
+        }
+
+        if($endTime) {
+            $where.=' AND ticket.created<=FROM_UNIXTIME('.$endTime.')';
+            $criteria['created__lte'] = $endTime;
+        }
+
+        // Dynamic fields
+        $cdata_search = false;
+        foreach (TicketForm::getInstance()->getFields() as $f) {
+            if (isset($req[$f->getFormName()])
+                    && ($val = $req[$f->getFormName()])) {
+                $name = $f->get('name') ? $f->get('name')
+                    : 'field_'.$f->get('id');
+                if (is_array($val)) {
+                    $cwhere = '(' . implode(' OR ', array_map(
+                        function($k) use ($name) {
+                            return sprintf('FIND_IN_SET(%s, `%s`)', db_input($k), $name);
+                        }, $val)
+                    ) . ')';
+                    $criteria["cdata.{$name}"] = $val;
+                }
+                else {
+                    $cwhere = "cdata.`$name` LIKE '%".db_real_escape($val)."%'";
+                    $criteria["cdata.{$name}"] = $val;
+                }
+                $where .= ' AND ('.$cwhere.')';
+                $cdata_search = true;
+            }
+        }
+        if ($cdata_search)
+            $from .= 'LEFT JOIN '.TABLE_PREFIX.'ticket__cdata '
+                    ." cdata ON (cdata.ticket_id = ticket.ticket_id)";
+
+        //Query
+        $joins = array();
+        if($req['query']) {
+            // Setup sets of joins and queries
+            if ($s = $ost->searcher)
+               return $s->find($req['query'], $criteria, 'Ticket');
+        }
+
+        $sections = array();
+        foreach ($joins as $j) {
+            $sections[] = "$select $from {$j['from']} $where AND ({$j['where']})";
+        }
+        if (!$joins)
+            $sections[] = "$select $from $where";
+
+        $sql=implode(' union ', $sections);
+        if (!($res = db_query($sql)))
+            return TicketForm::dropDynamicDataView();
+
+        $tickets = array();
+        while ($row = db_fetch_row($res))
+            $tickets[] = $row[0];
+
+        return $tickets;
+    }
+
+    function search() {
+        $tickets = self::_search($_REQUEST);
+        $result = array();
+
+        if (count($tickets)) {
+            $uid = md5($_SERVER['QUERY_STRING']);
+            $_SESSION["adv_$uid"] = $tickets;
+            $result['success'] = sprintf(__("Search criteria matched %s"),
+                    sprintf(_N('%d ticket', '%d tickets', count($tickets)), count($tickets)
+                ))
+                . " - <a href='tickets.php?advsid=$uid'>".__('view')."</a>";
+        } else {
+            $result['fail']=__('No tickets found matching your search criteria.');
+        }
+
+        return $this->json_encode($result);
+    }
+
+    function acquireLock($tid) {
+        global $cfg,$thisstaff;
+
+        if(!$tid || !is_numeric($tid) || !$thisstaff || !$cfg || !$cfg->getLockTime())
+            return 0;
+
+        if(!($ticket = Ticket::lookup($tid)) || !$ticket->checkStaffAccess($thisstaff))
+            return $this->json_encode(array('id'=>0, 'retry'=>false, 'msg'=>__('Lock denied!')));
+
+        //is the ticket already locked?
+        if($ticket->isLocked() && ($lock=$ticket->getLock()) && !$lock->isExpired()) {
+            /*Note: Ticket->acquireLock does the same logic...but we need it here since we need to know who owns the lock up front*/
+            //Ticket is locked by someone else.??
+            if($lock->getStaffId()!=$thisstaff->getId())
+                return $this->json_encode(array('id'=>0, 'retry'=>false, 'msg'=>__('Unable to acquire lock.')));
+
+            //Ticket already locked by staff...try renewing it.
+            $lock->renew(); //New clock baby!
+        } elseif(!($lock=$ticket->acquireLock($thisstaff->getId(),$cfg->getLockTime()))) {
+            //unable to obtain the lock..for some really weired reason!
+            //Client should watch for possible loop on retries. Max attempts?
+            return $this->json_encode(array('id'=>0, 'retry'=>true));
+        }
+
+        return $this->json_encode(array('id'=>$lock->getId(), 'time'=>$lock->getTime()));
+    }
+
+    function renewLock($tid, $id) {
+        global $thisstaff;
+
+        if(!$tid || !is_numeric($tid) || !$id || !is_numeric($id) || !$thisstaff)
+            return $this->json_encode(array('id'=>0, 'retry'=>true));
+
+        $lock= TicketLock::lookup($id, $tid);
+        if(!$lock || !$lock->getStaffId() || $lock->isExpired()) //Said lock doesn't exist or is is expired
+            return self::acquireLock($tid); //acquire the lock
+
+        if($lock->getStaffId()!=$thisstaff->getId()) //user doesn't own the lock anymore??? sorry...try to next time.
+            return $this->json_encode(array('id'=>0, 'retry'=>false)); //Give up...
+
+        //Renew the lock.
+        $lock->renew(); //Failure here is not an issue since the lock is not expired yet.. client need to check time!
+
+        return $this->json_encode(array('id'=>$lock->getId(), 'time'=>$lock->getTime()));
+    }
+
+    function releaseLock($tid, $id=0) {
+        global $thisstaff;
+
+        if($id && is_numeric($id)){ //Lock Id provided!
+
+            $lock = TicketLock::lookup($id, $tid);
+            //Already gone?
+            if(!$lock || !$lock->getStaffId() || $lock->isExpired()) //Said lock doesn't exist or is is expired
+                return 1;
+
+            //make sure the user actually owns the lock before releasing it.
+            return ($lock->getStaffId()==$thisstaff->getId() && $lock->release())?1:0;
+
+        }elseif($tid){ //release all the locks the user owns on the ticket.
+            return TicketLock::removeStaffLocks($thisstaff->getId(),$tid)?1:0;
+        }
+
+        return 0;
+    }
+
+    function previewTicket ($tid) {
+
+        global $thisstaff;
+
+        if(!$thisstaff || !($ticket=Ticket::lookup($tid)) || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, __('No such ticket'));
+
+        include STAFFINC_DIR . 'templates/ticket-preview.tmpl.php';
+    }
+
+    function addRemoteCollaborator($tid, $bk, $id) {
+        global $thisstaff;
+
+        if (!($ticket=Ticket::lookup($tid))
+                || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, 'No such ticket');
+        elseif (!$bk || !$id)
+            Http::response(422, 'Backend and user id required');
+        elseif (!($backend = StaffAuthenticationBackend::getBackend($bk)))
+            Http::response(404, 'User not found');
+
+        $user_info = $backend->lookup($id);
+        $form = UserForm::getUserForm()->getForm($user_info);
+        $info = array();
+        if (!$user_info)
+            $info['error'] = __('Unable to find user in directory');
+
+        return self::_addcollaborator($ticket, null, $form, $info);
+    }
+
+    //Collaborators utils
+    function addCollaborator($tid, $uid=0) {
+        global $thisstaff;
+
+        if (!($ticket=Ticket::lookup($tid))
+                || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, __('No such ticket'));
+
+
+        $user = $uid? User::lookup($uid) : null;
+
+        //If not a post then assume new collaborator form
+        if(!$_POST)
+            return self::_addcollaborator($ticket, $user);
+
+        $user = $form = null;
+        if (isset($_POST['id']) && $_POST['id']) { //Existing user/
+            $user =  User::lookup($_POST['id']);
+        } else { //We're creating a new user!
+            $form = UserForm::getUserForm()->getForm($_POST);
+            $user = User::fromForm($form);
+        }
+
+        $errors = $info = array();
+        if ($user) {
+            if ($user->getId() == $ticket->getOwnerId())
+                $errors['err'] = sprintf(__('Ticket owner, %s, is a collaborator by default!'),
+                        Format::htmlchars($user->getName()));
+            elseif (($c=$ticket->addCollaborator($user,
+                            array('isactive'=>1), $errors))) {
+                $note = Format::htmlchars(sprintf(__('%s <%s> added as a collaborator'),
+                            Format::htmlchars($c->getName()), $c->getEmail()));
+                $ticket->logNote(__('New Collaborator Added'), $note,
+                    $thisstaff, false);
+                $info = array('msg' => sprintf(__('%s added as a collaborator'),
+                            Format::htmlchars($c->getName())));
+                return self::_collaborators($ticket, $info);
+            }
+        }
+
+        if($errors && $errors['err']) {
+            $info +=array('error' => $errors['err']);
+        } else {
+            $info +=array('error' =>__('Unable to add collaborator. Internal error'));
+        }
+
+        return self::_addcollaborator($ticket, $user, $form, $info);
+    }
+
+    function updateCollaborator($cid) {
+        global $thisstaff;
+
+        if(!($c=Collaborator::lookup($cid))
+                || !($user=$c->getUser())
+                || !($ticket=$c->getTicket())
+                || !$ticket->checkStaffAccess($thisstaff)
+                )
+            Http::response(404, 'Unknown collaborator');
+
+        $errors = array();
+        if(!$user->updateInfo($_POST, $errors))
+            return self::_collaborator($c ,$user->getForms($_POST), $errors);
+
+        $info = array('msg' => sprintf('%s updated successfully',
+                    Format::htmlchars($c->getName())));
+
+        return self::_collaborators($ticket, $info);
+    }
+
+    function viewCollaborator($cid) {
+        global $thisstaff;
+
+        if(!($collaborator=Collaborator::lookup($cid))
+                || !($ticket=$collaborator->getTicket())
+                || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, 'Unknown collaborator');
+
+        return self::_collaborator($collaborator);
+    }
+
+    function showCollaborators($tid) {
+        global $thisstaff;
+
+        if(!($ticket=Ticket::lookup($tid))
+                || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, 'No such ticket');
+
+        if($ticket->getCollaborators())
+            return self::_collaborators($ticket);
+
+        return self::_addcollaborator($ticket);
+    }
+
+    function previewCollaborators($tid) {
+        global $thisstaff;
+
+        if (!($ticket=Ticket::lookup($tid))
+                || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, 'No such ticket');
+
+        ob_start();
+        include STAFFINC_DIR . 'templates/collaborators-preview.tmpl.php';
+        $resp = ob_get_contents();
+        ob_end_clean();
+
+        return $resp;
+    }
+
+    function _addcollaborator($ticket, $user=null, $form=null, $info=array()) {
+
+        $info += array(
+                    'title' => sprintf(__('Ticket #%s: Add a collaborator'), $ticket->getNumber()),
+                    'action' => sprintf('#tickets/%d/add-collaborator', $ticket->getId()),
+                    'onselect' => sprintf('ajax.php/tickets/%d/add-collaborator/', $ticket->getId()),
+                    );
+        return self::_userlookup($user, $form, $info);
+    }
+
+
+    function updateCollaborators($tid) {
+        global $thisstaff;
+
+        if(!($ticket=Ticket::lookup($tid))
+                || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, 'No such ticket');
+
+        $errors = $info = array();
+        if ($ticket->updateCollaborators($_POST, $errors))
+            Http::response(201, sprintf('Recipients (%d of %d)',
+                        $ticket->getNumActiveCollaborators(),
+                        $ticket->getNumCollaborators()));
+
+        if($errors && $errors['err'])
+            $info +=array('error' => $errors['err']);
+
+        return self::_collaborators($ticket, $info);
+    }
+
+
+
+    function _collaborator($collaborator, $form=null, $info=array()) {
+
+        $info += array('action' => '#collaborators/'.$collaborator->getId());
+
+        $user = $collaborator->getUser();
+
+        ob_start();
+        include(STAFFINC_DIR . 'templates/user.tmpl.php');
+        $resp = ob_get_contents();
+        ob_end_clean();
+
+        return $resp;
+    }
+
+    function _collaborators($ticket, $info=array()) {
+
+        ob_start();
+        include(STAFFINC_DIR . 'templates/collaborators.tmpl.php');
+        $resp = ob_get_contents();
+        ob_end_clean();
+
+        return $resp;
+    }
+
+    function viewUser($tid) {
+        global $thisstaff;
+
+        if(!$thisstaff
+                || !($ticket=Ticket::lookup($tid))
+                || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, 'No such ticket');
+
+
+        if(!($user = User::lookup($ticket->getOwnerId())))
+            Http::response(404, 'Unknown user');
+
+
+        $info = array(
+            'title' => sprintf(__('Ticket #%s: %s'), $ticket->getNumber(),
+                Format::htmlchars($user->getName()))
+            );
+
+        ob_start();
+        include(STAFFINC_DIR . 'templates/user.tmpl.php');
+        $resp = ob_get_contents();
+        ob_end_clean();
+        return $resp;
+
+    }
+
+    function updateUser($tid) {
+
+        global $thisstaff;
+
+        if(!$thisstaff
+                || !($ticket=Ticket::lookup($tid))
+                || !$ticket->checkStaffAccess($thisstaff)
+                || !($user = User::lookup($ticket->getOwnerId())))
+            Http::response(404, 'No such ticket/user');
+
+        $errors = array();
+        if($user->updateInfo($_POST, $errors, true))
+             Http::response(201, $user->to_json());
+
+        $forms = $user->getForms();
+
+        $info = array(
+            'title' => sprintf(__('Ticket #%s: %s'), $ticket->getNumber(),
+                Format::htmlchars($user->getName()))
+            );
+
+        ob_start();
+        include(STAFFINC_DIR . 'templates/user.tmpl.php');
+        $resp = ob_get_contents();
+        ob_end_clean();
+        return $resp;
+    }
+
+    function changeUserForm($tid) {
+        global $thisstaff;
+
+        if(!$thisstaff
+                || !($ticket=Ticket::lookup($tid))
+                || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, 'No such ticket');
+
+
+        $user = User::lookup($ticket->getOwnerId());
+
+        $info = array(
+                'title' => sprintf(__('Change user for ticket #%s'), $ticket->getNumber())
+                );
+
+        return self::_userlookup($user, null, $info);
+    }
+
+    function _userlookup($user, $form, $info) {
+
+        ob_start();
+        include(STAFFINC_DIR . 'templates/user-lookup.tmpl.php');
+        $resp = ob_get_contents();
+        ob_end_clean();
+        return $resp;
+
+    }
+
+    function manageForms($ticket_id) {
+        $forms = DynamicFormEntry::forTicket($ticket_id);
+        $info = array('action' => '#tickets/'.Format::htmlchars($ticket_id).'/forms/manage');
+        include(STAFFINC_DIR . 'templates/form-manage.tmpl.php');
+    }
+
+    function updateForms($ticket_id) {
+        global $thisstaff;
+
+        if (!$thisstaff)
+            Http::response(403, "Login required");
+        elseif (!($ticket = Ticket::lookup($ticket_id)))
+            Http::response(404, "No such ticket");
+        elseif (!$ticket->checkStaffAccess($thisstaff))
+            Http::response(403, "Access Denied");
+        elseif (!isset($_POST['forms']))
+            Http::response(422, "Send updated forms list");
+
+        // Add new forms
+        $forms = DynamicFormEntry::forTicket($ticket_id);
+        foreach ($_POST['forms'] as $sort => $id) {
+            $found = false;
+            foreach ($forms as $e) {
+                if ($e->get('form_id') == $id) {
+                    $e->set('sort', $sort);
+                    $e->save();
+                    $found = true;
+                    break;
+                }
+            }
+            // New form added
+            if (!$found && ($new = DynamicForm::lookup($id))) {
+                $f = $new->instanciate();
+                $f->set('sort', $sort);
+                $f->setTicketId($ticket_id);
+                $f->save();
+            }
+        }
+
+        // Deleted forms
+        foreach ($forms as $idx => $e) {
+            if (!in_array($e->get('form_id'), $_POST['forms']))
+                $e->delete();
+        }
+
+        Http::response(201, 'Successfully managed');
+    }
+
+    function cannedResponse($tid, $cid, $format='text') {
+        global $thisstaff, $cfg;
+
+        if (!($ticket = Ticket::lookup($tid))
+                || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, 'Unknown ticket ID');
+
+
+        if ($cid && !is_numeric($cid)) {
+            if (!($response=$ticket->getThread()->getVar($cid)))
+                Http::response(422, 'Unknown ticket variable');
+
+            // Ticket thread variables are assumed to be quotes
+            $response = "<br/><blockquote>{$response->asVar()}</blockquote><br/>";
+
+            //  Return text if html thread is not enabled
+            if (!$cfg->isHtmlThreadEnabled())
+                $response = Format::html2text($response, 90);
+            else
+                $response = Format::viewableImages($response);
+
+            // XXX: assuming json format for now.
+            return Format::json_encode(array('response' => $response));
+        }
+
+        if (!$cfg->isHtmlThreadEnabled())
+            $format.='.plain';
+
+        $varReplacer = function (&$var) use($ticket) {
+            return $ticket->replaceVars($var);
+        };
+
+        include_once(INCLUDE_DIR.'class.canned.php');
+        if (!$cid || !($canned=Canned::lookup($cid)) || !$canned->isEnabled())
+            Http::response(404, 'No such premade reply');
+
+        return $canned->getFormattedResponse($format, $varReplacer);
+    }
+
+    function changeTicketStatus($tid, $status, $id=0) {
+        global $thisstaff;
+
+        if (!$thisstaff)
+            Http::response(403, 'Access denied');
+        elseif (!$tid
+                || !($ticket=Ticket::lookup($tid))
+                || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, 'Unknown ticket #');
+
+        $info = array();
+        $state = null;
+        switch($status) {
+            case 'open':
+            case 'reopen':
+                $state = 'open';
+                break;
+            case 'close':
+                if (!$thisstaff->canCloseTickets())
+                    Http::response(403, 'Access denied');
+                $state = 'closed';
+                break;
+            case 'delete':
+                if (!$thisstaff->canDeleteTickets())
+                    Http::response(403, 'Access denied');
+                $state = 'deleted';
+                break;
+            default:
+                $state = $ticket->getStatus()->getState();
+                $info['warn'] = sprintf('%s %s',
+                        __('Unknown or invalid'), __('status'));
+        }
+
+        $info['status_id'] = $id ?: $ticket->getStatusId();
+
+        return self::_changeTicketStatus($ticket, $state, $info);
+    }
+
+    function setTicketStatus($tid) {
+        global $thisstaff, $ost;
+
+        if (!$thisstaff)
+            Http::response(403, 'Access denied');
+        elseif (!$tid
+                || !($ticket=Ticket::lookup($tid))
+                || !$ticket->checkStaffAccess($thisstaff))
+            Http::response(404, 'Unknown ticket #');
+
+        $errors = $info = array();
+        if (!$_POST['status_id']
+                || !($status= TicketStatus::lookup($_POST['status_id'])))
+            $errors['status_id'] = sprintf('%s %s',
+                    __('Unknown or invalid'), __('status'));
+        elseif ($status->getId() == $ticket->getStatusId())
+            $errors['err'] = sprintf(__('Ticket already set to %s status'),
+                    __($status->getName()));
+        else {
+            // Make sure the agent has permission to set the status
+            switch(mb_strtolower($status->getState())) {
+                case 'open':
+                    if (!$thisstaff->canCloseTickets()
+                            && !$thisstaff->canCreateTickets())
+                        $errors['err'] = sprintf(__('You do not have permission %s.'),
+                                __('to reopen tickets'));
+                    break;
+                case 'closed':
+                    if (!$thisstaff->canCloseTickets())
+                        $errors['err'] = sprintf(__('You do not have permission %s.'),
+                                __('to resolve/close tickets'));
+                    break;
+                case 'deleted':
+                    if (!$thisstaff->canDeleteTickets())
+                        $errors['err'] = sprintf(__('You do not have permission %s.'),
+                                __('to archive/delete tickets'));
+                    break;
+                default:
+                    $errors['err'] = sprintf('%s %s',
+                            __('Unknown or invalid'), __('status'));
+            }
+        }
+
+        $state = strtolower($status->getState());
+
+        if (!$errors && $ticket->setStatus($status, $_REQUEST['comments'])) {
+
+            if ($state == 'deleted') {
+                $msg = sprintf('%s %s',
+                        sprintf(__('Ticket #%s'), $ticket->getNumber()),
+                        __('deleted sucessfully')
+                        );
+            } elseif ($state != 'open') {
+                 $msg = sprintf(__('%s status changed to %s'),
+                         sprintf(__('Ticket #%s'), $ticket->getNumber()),
+                         $status->getName());
+            } else {
+                $msg = sprintf(
+                        __('%s status changed to %s'),
+                        __('Ticket'),
+                        $status->getName());
+            }
+
+            $_SESSION['::sysmsgs']['msg'] = $msg;
+
+            Http::response(201, 'Successfully processed');
+        } elseif (!$errors['err']) {
+            $errors['err'] =  __('Error updating ticket status');
+        }
+
+        $state = $state ?: $ticket->getStatus()->getState();
+        $info['status_id'] = $status
+            ? $status->getId() : $ticket->getStatusId();
+
+        return self::_changeTicketStatus($ticket, $state, $info, $errors);
+    }
+
+    function changeSelectedTicketsStatus($status, $id=0) {
+        global $thisstaff, $cfg;
+
+        if (!$thisstaff)
+            Http::response(403, 'Access denied');
+
+        $state = null;
+        $info = array();
+        switch($status) {
+            case 'open':
+            case 'reopen':
+                $state = 'open';
+                break;
+            case 'close':
+                if (!$thisstaff->canCloseTickets())
+                    Http::response(403, 'Access denied');
+                $state = 'closed';
+                break;
+            case 'delete':
+                if (!$thisstaff->canDeleteTickets())
+                    Http::response(403, 'Access denied');
+
+                $state = 'deleted';
+                break;
+            default:
+                $info['warn'] = sprintf('%s %s',
+                        __('Unknown or invalid'), __('status'));
+        }
+
+        $info['status_id'] = $id;
+
+        return self::_changeSelectedTicketsStatus($state, $info);
+    }
+
+    function setSelectedTicketsStatus($state) {
+        global $thisstaff, $ost;
+
+        $errors = $info = array();
+        if (!$thisstaff || !$thisstaff->canManageTickets())
+            $errors['err'] = sprintf('%s %s',
+                    sprintf(__('You do not have permission %s.'),
+                        __('to mass manage tickets')),
+                    __('Contact admin for such access'));
+        elseif (!$_REQUEST['tids'] || !count($_REQUEST['tids']))
+            $errors['err']=sprintf(__('You must select at least %s.'),
+                    __('one ticket'));
+        elseif (!($status= TicketStatus::lookup($_REQUEST['status_id'])))
+            $errors['status_id'] = sprintf('%s %s',
+                    __('Unknown or invalid'), __('status'));
+        elseif (!$errors) {
+            // Make sure the agent has permission to set the status
+            switch(mb_strtolower($status->getState())) {
+                case 'open':
+                    if (!$thisstaff->canCloseTickets()
+                            && !$thisstaff->canCreateTickets())
+                        $errors['err'] = sprintf(__('You do not have permission %s.'),
+                                __('to reopen tickets'));
+                    break;
+                case 'closed':
+                    if (!$thisstaff->canCloseTickets())
+                        $errors['err'] = sprintf(__('You do not have permission %s.'),
+                                __('to resolve/close tickets'));
+                    break;
+                case 'deleted':
+                    if (!$thisstaff->canDeleteTickets())
+                        $errors['err'] = sprintf(__('You do not have permission %s.'),
+                                __('to archive/delete tickets'));
+                    break;
+                default:
+                    $errors['err'] = sprintf('%s %s',
+                            __('Unknown or invalid'), __('status'));
+            }
+        }
+
+        $count = count($_REQUEST['tids']);
+        if (!$errors) {
+            $i = 0;
+            $comments = $_REQUEST['comments'];
+            foreach ($_REQUEST['tids'] as $tid) {
+                if (($ticket=Ticket::lookup($tid))
+                        && $ticket->getStatusId() != $status->getId()
+                        && $ticket->checkStaffAccess($thisstaff)
+                        && $ticket->setStatus($status, $comments))
+                    $i++;
+            }
+
+            if (!$i)
+                $errors['err'] = sprintf(__('Unable to change status for %s'),
+                        _N('the selected ticket', 'any of the selected tickets', $count));
+            else {
+                // Assume success
+                if ($i==$count) {
+
+                    if (!strcasecmp($status->getState(), 'deleted')) {
+                        $msg = sprintf(__( 'Successfully deleted %s.'),
+                                _N('selected ticket', 'selected tickets',
+                                    $count));
+                    } else {
+                       $msg = sprintf(
+                            __(
+                                /* 1$ will be 'selected ticket(s)', 2$ is the new status */
+                                'Successfully changed status of %1$s to %2$s'),
+                            _N('selected ticket', 'selected tickets',
+                                $count),
+                            $status->getName());
+                    }
+
+                    $_SESSION['::sysmsgs']['msg'] = $msg;
+                } else {
+
+                    if (!strcasecmp($status->getState(), 'deleted')) {
+                        $warn = sprintf(__('Successfully deleted %s.'),
+                                sprintf(__('%1$d of %2$d selected tickets'),
+                                    $i, $count)
+                                );
+                    } else {
+
+                        $warn = sprintf(
+                                __('%1$d of %2$d %3$s status changed to %4$s'),$i, $count,
+                                _N('selected ticket', 'selected tickets',
+                                    $count),
+                                $status->getName());
+                    }
+
+                    $_SESSION['::sysmsgs']['warn'] = $warn;
+                }
+
+                Http::response(201, 'Successfully processed');
+            }
+        }
+
+        return self::_changeSelectedTicketsStatus($state, $info, $errors);
+    }
+
+    private function _changeSelectedTicketsStatus($state, $info=array(), $errors=array()) {
+
+        $count = $_REQUEST['count'] ?:
+            ($_REQUEST['tids'] ?  count($_REQUEST['tids']) : 0);
+
+        $info['title'] = sprintf(__('%1$s Tickets &mdash; %2$d selected'),
+                TicketStateField::getVerb($state),
+                 $count);
+
+        if (!strcasecmp($state, 'deleted')) {
+
+            $info['warn'] = sprintf(__(
+                        'Are you sure you want to DELETE %s?'),
+                    _N('selected ticket', 'selected tickets', $count)
+                    );
+
+            $info['extra'] = sprintf('<strong>%s</strong>', __(
+                        'Deleted tickets CANNOT be recovered, including any associated attachments.')
+                    );
+
+            $info['placeholder'] = sprintf(__(
+                        'Optional reason for deleting %s'),
+                    _N('selected ticket', 'selected tickets', $count));
+        }
+
+        $info['status_id'] = $info['status_id'] ?: $_REQUEST['status_id'];
+        $info['comments'] = Format::htmlchars($_REQUEST['comments']);
+
+        return self::_changeStatus($state, $info, $errors);
+    }
+
+    private function _changeTicketStatus($ticket, $state, $info=array(), $errors=array()) {
+
+        $verb = TicketStateField::getVerb($state);
+
+        $info['action'] = sprintf('#tickets/%d/status', $ticket->getId());
+        $info['title'] = sprintf(__(
+                    /* 1$ will be a verb, like 'open', 2$ will be the ticket number */
+                    '%1$s Ticket #%2$s'),
+                $verb ?: $state,
+                $ticket->getNumber()
+                );
+
+        // Deleting?
+        if (!strcasecmp($state, 'deleted')) {
+
+            $info['placeholder'] = sprintf(__(
+                        'Optional reason for deleting %s'),
+                    __('this ticket'));
+            $info[ 'warn'] = sprintf(__(
+                        'Are you sure you want to DELETE %s?'),
+                        __('this ticket'));
+            //TODO: remove message below once we ship data retention plug
+            $info[ 'extra'] = sprintf('<strong>%s</strong>',
+                        __('Deleted tickets CANNOT be recovered, including any associated attachments.')
+                        );
+        }
+
+        $info['status_id'] = $info['status_id'] ?: $ticket->getStatusId();
+        $info['comments'] = Format::htmlchars($_REQUEST['comments']);
+
+        return self::_changeStatus($state, $info, $errors);
+    }
+
+    private function _changeStatus($state, $info=array(), $errors=array()) {
+
+        if ($info && isset($info['errors']))
+            $errors = array_merge($errors, $info['errors']);
+
+        if (!$info['error'] && isset($errors['err']))
+            $info['error'] = $errors['err'];
+
+        include(STAFFINC_DIR . 'templates/ticket-status.tmpl.php');
+    }
+}

--- a/class.search.php
+++ b/class.search.php
@@ -1,0 +1,763 @@
+<?php
+/*********************************************************************
+    module.search.php
+
+    Search Engine for osTicket
+
+    This module defines the pieces for a search engine for osTicket.
+    Searching can be performed by various search engine backends which can
+    make use of the features of various search providers.
+
+    A reference search engine backend is provided which uses MySQL MyISAM
+    tables. This default backend should not be used on Galera clusters.
+
+    Jared Hancock <jared@osticket.com>
+    Peter Rotich <peter@osticket.com>
+    Copyright (c)  2006-2013 osTicket
+    http://www.osticket.com
+
+    Released under the GNU General Public License WITHOUT ANY WARRANTY.
+    See LICENSE.TXT for details.
+
+    vim: expandtab sw=4 ts=4 sts=4:
+**********************************************************************/
+
+session_start();
+
+abstract class SearchBackend {
+    static $id = false;
+    static $registry = array();
+
+    const SORT_RELEVANCE = 1;
+    const SORT_RECENT = 2;
+    const SORT_OLDEST = 3;
+
+    abstract function update($model, $id, $content, $new=false, $attrs=array());
+    abstract function find($query, $criteria, $model=false, $sort=array());
+
+    static function register($backend=false) {
+        $backend = $backend ?: get_called_class();
+
+        if ($backend::$id == false)
+            throw new Exception('SearchBackend must define an ID');
+
+        static::$registry[$backend::$id] = $backend;
+    }
+
+    function getInstance($id) {
+        if (!isset(self::$registry[$id]))
+            return null;
+
+        return new self::$registry[$id]();
+    }
+}
+
+// Register signals to intercept saving of various content throughout the
+// system
+
+class SearchInterface {
+
+    var $backend;
+
+    function __construct() {
+        $this->bootstrap();
+    }
+
+    function find($query, $criteria, $model=false, $sort=array()) {
+        $query = Format::searchable($query);
+        return $this->backend->find($query, $criteria, $model, $sort);
+    }
+
+    function update($model, $id, $content, $new=false, $attrs=array()) {
+        if (!$this->backend)
+            return;
+
+        $this->backend->update($model, $id, $content, $new, $attrs);
+    }
+
+    function createModel($model) {
+        return $this->updateModel($model, true);
+    }
+
+    function updateModel($model, $new=false) {
+        // The MySQL backend does not need to index attributes of the
+        // various models, because those other attributes are available in
+        // the local database in other tables.
+        switch (true) {
+        case $model instanceof ThreadEntry:
+            // Only index an entry for threads if a human created the
+            // content
+            if (!$model->getUserId() && !$model->getStaffId())
+                break;
+
+            $this->update($model, $model->getId(),
+                $model->getBody()->getSearchable(), $new,
+                array(
+                    'title' =>      $model->getTitle(),
+                    'ticket_id' =>  $model->getTicketId(),
+                    'created' =>    $model->getCreateDate(),
+                )
+            );
+            break;
+
+        case $model instanceof Ticket:
+            $cdata = array();
+            foreach ($model->loadDynamicData() as $a)
+                if ($v = $a->getSearchable())
+                    $cdata[] = $v;
+            $this->update($model, $model->getId(),
+                trim(implode("\n", $cdata)),
+                $new,
+                array(
+                    'title'=>       Format::searchable($model->getSubject()),
+                    'number'=>      $model->getNumber(),
+                    'status'=>      $model->getStatus(),
+                    'topic_id'=>    $model->getTopicId(),
+                    'priority_id'=> $model->getPriorityId(),
+                    // Stats (comments, attachments)
+                    // Access constraints
+                    'dept_id'=>     $model->getDeptId(),
+                    'staff_id'=>    $model->getStaffId(),
+                    'team_id'=>     $model->getTeamId(),
+                    // Sorting and ranging preferences
+                    'created'=>     $model->getCreateDate(),
+                    // Add last-updated timestamp
+                )
+            );
+            break;
+
+        case $model instanceof User:
+            $cdata = array();
+            foreach ($model->getDynamicData($false) as $e)
+                foreach ($e->getAnswers() as $tag=>$a)
+                    if ($tag != 'subject' && ($v = $a->getSearchable()))
+                        $cdata[] = $v;
+            $this->update($model, $model->getId(),
+                trim(implode("\n", $cdata)),
+                $new,
+                array(
+                    'title'=>       Format::searchable($model->getFullName()),
+                    'emails'=>      $model->emails->asArray(),
+                    'org_id'=>      $model->getOrgId(),
+                    'created'=>     $model->getCreateDate(),
+                )
+            );
+            break;
+
+        case $model instanceof Organization:
+            $cdata = array();
+            foreach ($model->getDynamicData(false) as $e)
+                foreach ($e->getAnswers() as $a)
+                    if ($v = $a->getSearchable())
+                        $cdata[] = $v;
+            $this->update($model, $model->getId(),
+                trim(implode("\n", $cdata)),
+                $new,
+                array(
+                    'title'=>       Format::searchable($model->getName()),
+                    'created'=>     $model->getCreateDate(),
+                )
+            );
+            break;
+
+        case $model instanceof FAQ:
+            $this->update($model, $model->getId(),
+                $model->getSearchableAnswer(),
+                $new,
+                array(
+                    'title'=>       Format::searchable($model->getQuestion()),
+                    'keywords'=>    $model->getKeywords(),
+                    'topics'=>      $model->getHelpTopicsIds(),
+                    'category_id'=> $model->getCategoryId(),
+                    'created'=>     $model->getCreateDate(),
+                )
+            );
+            break;
+
+        default:
+            // Not indexed
+            break;
+        }
+    }
+
+    function bootstrap() {
+        // Determine the backend
+        if (defined('SEARCH_BACKEND'))
+            $bk = SearchBackend::getInstance(SEARCH_BACKEND);
+
+        if (!$bk && !($bk = SearchBackend::getInstance('mysql')))
+            // No backend registered or defined
+            return false;
+
+        $this->backend = $bk;
+        $this->backend->bootstrap();
+
+        $self = $this;
+
+        // Thread entries
+        // Tickets, which can be edited as well
+        // Knowledgebase articles (FAQ and canned responses)
+        // Users, organizations
+        Signal::connect('model.created', array($this, 'createModel'));
+        Signal::connect('model.updated', array($this, 'updateModel'));
+        #Signal::connect('model.deleted', array($this, 'deleteModel'));
+    }
+}
+
+require_once(INCLUDE_DIR.'class.config.php');
+class MySqlSearchConfig extends Config {
+    var $table = CONFIG_TABLE;
+
+    function __construct() {
+        parent::Config("mysqlsearch");
+    }
+}
+
+class MysqlSearchBackend extends SearchBackend {
+    static $id = 'mysql';
+    static $BATCH_SIZE = 30;
+
+    // Only index 20 batches per cron run
+    var $max_batches = 60;
+    var $_reindexed = 0;
+
+    function __construct() {
+        $this->SEARCH_TABLE = TABLE_PREFIX . '_search';
+    }
+
+    function getConfig() {
+        if (!isset($this->config))
+            $this->config = new MySqlSearchConfig();
+        return $this->config;
+    }
+
+
+    function bootstrap() {
+        if ($this->getConfig()->get('reindex', true))
+            Signal::connect('cron', array($this, 'IndexOldStuff'));
+    }
+
+    function update($model, $id, $content, $new=false, $attrs=array()) {
+        switch (true) {
+        case $model instanceof ThreadEntry:
+            $type = 'H';
+            break;
+        case $model instanceof Ticket:
+            $attrs['title'] = $attrs['number'].' '.$attrs['title'];
+            $type = 'T';
+            break;
+        case $model instanceof User:
+            $content .= implode("\n", $attrs['emails']);
+            $type = 'U';
+            break;
+        case $model instanceof Organization:
+            $type = 'O';
+            break;
+        case $model instanceof FAQ:
+            $type = 'K';
+            break;
+        case $model instanceof AttachmentFile:
+            $type = 'F';
+            break;
+        default:
+            // Not indexed
+            return;
+        }
+
+        $title = $attrs['title'] ?: '';
+
+        if (!$content && !$title)
+            return;
+
+        $sql = 'REPLACE INTO '.$this->SEARCH_TABLE
+            . ' SET object_type='.db_input($type)
+            . ', object_id='.db_input($id)
+            . ', content='.db_input($content)
+            . ', title='.db_input($title);
+        return db_query($sql);
+    }
+
+    // Quote things like email addresses
+    function quote($query) {
+        $parts = array();
+        if (!preg_match_all('`([^\s"\']+)|"[^"]*"|\'[^\']*\'`', $query, $parts,
+                PREG_SET_ORDER))
+            return $query;
+
+        $results = array();
+        foreach ($parts as $m) {
+            // Check for quoting
+            if ($m[1] // Already quoted?
+                && preg_match('`@`u', $m[0])
+            ) {
+                $char = strpos($m[1], '"') ? "'" : '"';
+                $m[0] = $char . $m[0] . $char;
+            }
+            $results[] = $m[0];
+        }
+        return implode(' ', $results);
+    }
+
+	function find2($query, $criteria=array(), $model=false, $sort=array()) {
+    
+    /*
+    CREATE VIEW ost_pjh_search AS 
+    SELECT DISTINCT tt.ticket_id, tt.title, st.state, st.id AS state_id, t.user_id, us.name AS user_name , 
+    t.staff_id AS assigned_to_id, t.staff_id AS staff_id, t.created AS created_date, UNIX_TIMESTAMP(t.created) AS created 
+    FROM `ost_ticket_thread` tt 
+    left join ost_ticket t ON t.ticket_id = tt.ticket_id
+    left join ost_ticket_status st ON st.id = t.status_id 
+    left join ost_user us ON t.user_id = us.id 
+    GROUP BY 1
+    ORDER BY 1 DESC
+    */
+		
+    global $thisstaff;
+		
+    $query = $this->quote($query.'%');
+        
+		$tables = array();
+        
+		$P = TABLE_PREFIX;
+        
+		$sort = '';
+		
+	  $class = get_class();
+        
+		$auto_create = function($db_error) use ($class){
+
+    if ($db_error != 1146)
+        // Perform the standard error handling
+        return true;
+
+        // Create the search table automatically
+        $class::createSearchTable();
+    };
+		
+		$where[] = sprintf("title like %s", db_input($query));
+		
+		if ($criteria) {            
+                foreach ($criteria as $name=>$value) {
+                    switch ($name) {
+                    case 'status_id':
+                        $where[] = 'state_id = '.db_input($value);
+                        break;
+                    case 'state':
+                        $where[] = 'state = '.db_input($value);
+                        break;
+                    case 'state__in':
+                        $where[] = 'state IN ('.implode(',',db_input($value)).')';
+                        break;
+                    case 'topic_id':
+                    case 'staff_id':
+						            /*$where[] = 'assigned_to_id = '.db_input($value);
+                        break;*/
+                    case 'team_id':
+                    case 'dept_id':
+                    case 'user_id':
+                    case 'isanswered':
+                    case 'isoverdue':
+                    case 'number':
+                        $where[] = sprintf('%s = %s', $name, db_input($value));
+                        break;
+                    
+                    case 'created__gte':
+                        $where[] = sprintf('created >= %s', db_input($value));
+                        break;
+
+                    case 'created__lte':
+                        $where[] = sprintf('created <= %s', db_input($value));
+                        break;
+                    
+                    case 'email':
+                    case 'org_id':
+                    case 'form_id':
+					default: 
+					   $where[] = "state = 'open'";
+					}
+				}
+		}
+		
+		$final = implode(" AND ", $where);
+		
+		$sql = sprintf("select ticket_id from ost_pjh_search where %s", $final);
+		
+		$_SESSION['osticket_sql'] = $sql;
+		
+		$_SESSION['r'] = $_REQUEST;
+    
+    $_SESSION['criteria'] = $criteria;
+		
+    $res = db_query($sql, $auto_create);
+    $object_ids = array();
+
+    while ($row = db_fetch_row($res))
+        $object_ids[] = $row[0];
+
+    return $object_ids;
+	
+	  }
+	
+    function find($query, $criteria=array(), $model=false, $sort=array()) {
+        global $thisstaff;
+
+        $mode = ' IN BOOLEAN MODE';
+        #if (count(explode(' ', $query)) == 1)
+        #    $mode = ' WITH QUERY EXPANSION';
+        $query = $this->quote($query);
+        $search = 'MATCH (search.title, search.content) AGAINST ('
+            .db_input($query)
+            .$mode.')';
+        $tables = array();
+        $P = TABLE_PREFIX;
+        $sort = '';
+
+        if ($query) {
+            $tables[] = "(
+                SELECT object_type, object_id, $search AS `relevance`
+                FROM `{$P}_search` `search`
+                WHERE $search
+            ) `search`";
+            $sort = 'ORDER BY `search`.`relevance`';
+        }
+
+        switch ($model) {
+        case false:
+        case 'Ticket':
+            
+            return $this->find2($query, $criteria, $model, $sort);
+		
+            $tables[] = "(select ticket_id as ticket_id from {$P}ticket
+            ) B1 ON (B1.ticket_id = search.object_id and search.object_type = 'T')";
+            $tables[] = "(select A2.id as thread_id, A1.ticket_id from {$P}ticket A1
+                join {$P}ticket_thread A2 on (A1.ticket_id = A2.ticket_id)
+            ) B2 ON (B2.thread_id = search.object_id and search.object_type = 'H')";
+            $tables[] = "(select A3.id as user_id, A1.ticket_id from {$P}user A3
+                join {$P}ticket A1 on (A1.user_id = A3.id)
+            ) B3 ON (B3.user_id = search.object_id and search.object_type = 'U')";
+            $tables[] = "(select A4.id as org_id, A1.ticket_id from {$P}organization A4
+                join {$P}user A3 on (A3.org_id = A4.id) join {$P}ticket A1 on (A1.user_id = A3.id)
+            ) B4 ON (B4.org_id = search.object_id and search.object_type = 'O')";
+            $key = 'COALESCE(B1.ticket_id, B2.ticket_id, B3.ticket_id, B4.ticket_id)';
+            $tables[] = "{$P}ticket A1 ON (A1.ticket_id = {$key})";
+            $tables[] = "{$P}ticket_status A2 ON (A1.status_id = A2.id)";
+            $cdata_search = false;
+            $where = array();
+
+            if ($criteria) {
+                foreach ($criteria as $name=>$value) {
+                    switch ($name) {
+                    case 'status_id':
+                        $where[] = 'A2.id = '.db_input($value);
+                        break;
+                    case 'state':
+                        $where[] = 'A2.state = '.db_input($value);
+                        break;
+                    case 'state__in':
+                        $where[] = 'A2.state IN ('.implode(',',db_input($value)).')';
+                        break;
+                    case 'topic_id':
+                    case 'staff_id':
+                    case 'team_id':
+                    case 'dept_id':
+                    case 'user_id':
+                    case 'isanswered':
+                    case 'isoverdue':
+                    case 'number':
+                        $where[] = sprintf('A1.%s = %s', $name, db_input($value));
+                        break;
+                    case 'created__gte':
+                        $where[] = sprintf('A1.created >= %s', db_input($value));
+                        break;
+                    case 'created__lte':
+                        $where[] = sprintf('A1.created <= %s', db_input($value));
+                        break;
+                    case 'email':
+                    case 'org_id':
+                    case 'form_id':
+                    default:
+                        if (strpos($name, 'cdata.') === 0) {
+                            // Search ticket CDATA table
+                            $cdata_search = true;
+                            $name = substr($name, 6);
+                            if (is_array($value)) {
+                                $where[] = '(' . implode(' OR ', array_map(
+                                    function($k) use ($name) {
+                                        return sprintf('FIND_IN_SET(%s, cdata.`%s`)',
+                                            db_input($k), $name);
+                                    }, $value)
+                                ) . ')';
+                            }
+                            else {
+                                $where[] = sprintf("cdata.%s = %s", $name, db_input($value));
+                            }
+                        }
+                    }
+                }
+            }
+            if ($cdata_search)
+                $tables[] = TABLE_PREFIX.'ticket__cdata cdata'
+                    .' ON (cdata.ticket_id = A1.ticket_id)';
+
+            // Always consider the current staff's access
+            $thisstaff->getDepts();
+            $access = array();
+            $access[] = '(A1.staff_id=' . db_input($thisstaff->getId())
+                .' AND A2.state="open")';
+
+            if (!$thisstaff->showAssignedOnly() && ($depts=$thisstaff->getDepts()))
+                $access[] = 'A1.dept_id IN ('
+                    . ($depts ? implode(',', db_input($depts)) : 0)
+                    . ')';
+
+            if (($teams = $thisstaff->getTeams()) && count(array_filter($teams)))
+                $access[] = 'A1.team_id IN ('
+                    .implode(',', db_input(array_filter($teams)))
+                    .') AND A2.state="open"';
+
+            $where[] = '(' . implode(' OR ', $access) . ')';
+
+            // TODO: Consider sorting preferences
+
+            $sql = 'SELECT DISTINCT '
+                . $key
+                . ' FROM '
+                . implode(' LEFT JOIN ', $tables)
+                . ' WHERE ' . implode(' AND ', $where)
+                . $sort
+                . ' LIMIT 500';
+        }
+
+		
+		$_SESSION['osticket_sql'] = $sql;
+		
+        $class = get_class();
+        $auto_create = function($db_error) use ($class) {
+
+            if ($db_error != 1146)
+                // Perform the standard error handling
+                return true;
+
+            // Create the search table automatically
+            $class::createSearchTable();
+        };
+        $res = db_query($sql, $auto_create);
+        $object_ids = array();
+
+        while ($row = db_fetch_row($res))
+            $object_ids[] = $row[0];
+
+        return $object_ids;
+    }
+
+    static function createSearchTable() {
+        // Use InnoDB with Galera, MyISAM with v5.5, and the database
+        // default otherwise
+        $sql = "select count(*) from information_schema.tables where
+            table_schema='information_schema' and table_name =
+            'INNODB_FT_CONFIG'";
+        $mysql56 = db_result(db_query($sql));
+
+        $sql = "show status like 'wsrep_local_state'";
+        $galera = db_result(db_query($sql));
+
+        if ($galera && !$mysql56)
+            throw new Exception('Galera cannot be used with MyISAM tables');
+        $engine = $galera ? 'InnodB' : ($mysql56 ? '' : 'MyISAM');
+        if ($engine)
+            $engine = 'ENGINE='.$engine;
+
+        $sql = 'CREATE TABLE IF NOT EXISTS '.TABLE_PREFIX."_search (
+            `object_type` varchar(8) not null,
+            `object_id` int(11) unsigned not null,
+            `title` text collate utf8_general_ci,
+            `content` text collate utf8_general_ci,
+            primary key `object` (`object_type`, `object_id`),
+            fulltext key `search` (`title`, `content`)
+        ) $engine CHARSET=utf8";
+        return db_query($sql);
+    }
+
+    /**
+     * Cooperates with the cron system to automatically find content that is
+     * not index in the _search table and add it to the index.
+     */
+    function IndexOldStuff() {
+        $class = get_class();
+        $auto_create = function($db_error) use ($class) {
+
+            if ($db_error != 1146)
+                // Perform the standard error handling
+                return true;
+
+            // Create the search table automatically
+            $class::__init();
+
+        };
+
+        // THREADS ----------------------------------
+
+        $sql = "SELECT A1.`id`, A1.`title`, A1.`body`, A1.`format` FROM `".TICKET_THREAD_TABLE."` A1
+            LEFT JOIN `".TABLE_PREFIX."_search` A2 ON (A1.`id` = A2.`object_id` AND A2.`object_type`='H')
+            WHERE A2.`object_id` IS NULL AND (A1.poster <> 'SYSTEM')
+            AND (LENGTH(A1.`title`) + LENGTH(A1.`body`) > 0)
+            ORDER BY A1.`id` DESC";
+        if (!($res = db_query_unbuffered($sql, $auto_create)))
+            return false;
+
+        while ($row = db_fetch_row($res)) {
+            $body = ThreadBody::fromFormattedText($row[2], $row[3]);
+            $body = $body->getSearchable();
+            $title = Format::searchable($row[1]);
+            if (!$body && !$title)
+                continue;
+            $record = array('H', $row[0], $title, $body);
+            if (!$this->__index($record))
+                return;
+        }
+
+        // TICKETS ----------------------------------
+
+        $sql = "SELECT A1.`ticket_id` FROM `".TICKET_TABLE."` A1
+            LEFT JOIN `".TABLE_PREFIX."_search` A2 ON (A1.`ticket_id` = A2.`object_id` AND A2.`object_type`='T')
+            WHERE A2.`object_id` IS NULL
+            ORDER BY A1.`ticket_id` DESC";
+        if (!($res = db_query_unbuffered($sql, $auto_create)))
+            return false;
+
+        while ($row = db_fetch_row($res)) {
+            $ticket = Ticket::lookup($row[0]);
+            $cdata = $ticket->loadDynamicData();
+            $content = array();
+            foreach ($cdata as $k=>$a)
+                if ($k != 'subject' && ($v = $a->getSearchable()))
+                    $content[] = $v;
+            $record = array('T', $ticket->getId(),
+                Format::searchable($ticket->getNumber().' '.$ticket->getSubject()),
+                implode("\n", $content));
+            if (!$this->__index($record))
+                return;
+        }
+
+        // USERS ------------------------------------
+
+        $sql = "SELECT A1.`id` FROM `".USER_TABLE."` A1
+            LEFT JOIN `".TABLE_PREFIX."_search` A2 ON (A1.`id` = A2.`object_id` AND A2.`object_type`='U')
+            WHERE A2.`object_id` IS NULL
+            ORDER BY A1.`id` DESC";
+        if (!($res = db_query_unbuffered($sql, $auto_create)))
+            return false;
+
+        while ($row = db_fetch_row($res)) {
+            $user = User::lookup($row[0]);
+            $cdata = $user->getDynamicData();
+            $content = array();
+            foreach ($user->emails as $e)
+                $content[] = $e->address;
+            foreach ($cdata as $e)
+                foreach ($e->getAnswers() as $a)
+                    if ($c = $a->getSearchable())
+                        $content[] = $c;
+            $record = array('U', $user->getId(),
+                Format::searchable($user->getFullName()),
+                trim(implode("\n", $content)));
+            if (!$this->__index($record))
+                return;
+        }
+
+        // ORGANIZATIONS ----------------------------
+
+        $sql = "SELECT A1.`id` FROM `".ORGANIZATION_TABLE."` A1
+            LEFT JOIN `".TABLE_PREFIX."_search` A2 ON (A1.`id` = A2.`object_id` AND A2.`object_type`='O')
+            WHERE A2.`object_id` IS NULL
+            ORDER BY A1.`id` DESC";
+        if (!($res = db_query_unbuffered($sql, $auto_create)))
+            return false;
+
+        while ($row = db_fetch_row($res)) {
+            $org = Organization::lookup($row[0]);
+            $cdata = $org->getDynamicData();
+            $content = array();
+            foreach ($cdata as $e)
+                foreach ($e->getAnswers() as $a)
+                    if ($c = $a->getSearchable())
+                        $content[] = $c;
+            $record = array('O', $org->getId(),
+                Format::searchable($org->getName()),
+                trim(implode("\n", $content)));
+            if (!$this->__index($record))
+                return null;
+        }
+
+        // KNOWLEDGEBASE ----------------------------
+
+        require_once INCLUDE_DIR . 'class.faq.php';
+        $sql = "SELECT A1.`faq_id` FROM `".FAQ_TABLE."` A1
+            LEFT JOIN `".TABLE_PREFIX."_search` A2 ON (A1.`faq_id` = A2.`object_id` AND A2.`object_type`='K')
+            WHERE A2.`object_id` IS NULL
+            ORDER BY A1.`faq_id` DESC";
+        if (!($res = db_query_unbuffered($sql, $auto_create)))
+            return false;
+
+        while ($row = db_fetch_row($res)) {
+            $faq = FAQ::lookup($row[0]);
+            $q = $faq->getQuestion();
+            if ($k = $faq->getKeywords())
+                $q = $k.' '.$q;
+            $record = array('K', $faq->getId(),
+                Format::searchable($q),
+                $faq->getSearchableAnswer());
+            if (!$this->__index($record))
+                return;
+        }
+
+        // FILES ------------------------------------
+
+        // Flush non-full batch of records
+        $this->__index(null, true);
+
+        if (!$this->_reindexed) {
+            // Stop rebuilding the index
+            $this->getConfig()->set('reindex', 0);
+        }
+    }
+
+    function __index($record, $force_flush=false) {
+        static $queue = array();
+
+        if ($record)
+            $queue[] = $record;
+        elseif (!$queue)
+            return;
+
+        if (!$force_flush && count($queue) < $this::$BATCH_SIZE)
+            return true;
+
+        foreach ($queue as &$r)
+            $r = sprintf('(%s)', implode(',', db_input($r)));
+        unset($r);
+
+        $sql = 'INSERT INTO `'.TABLE_PREFIX.'_search` (`object_type`, `object_id`, `title`, `content`)
+            VALUES '.implode(',', $queue);
+        if (!db_query($sql, false) || count($queue) != db_affected_rows())
+            throw new Exception('Unable to index content');
+
+        $this->_reindexed += count($queue);
+        $queue = array();
+
+        if (!--$this->max_batches)
+            return null;
+
+        return true;
+    }
+
+    static function __init() {
+        self::createSearchTable();
+    }
+
+}
+
+Signal::connect('system.install',
+        array('MysqlSearchBackend', '__init'));
+
+MysqlSearchBackend::register();


### PR DESCRIPTION
Advanced search was killing my MySQL due to what looks like a cartesian join on the _search table.

N.B. Only class.search.php and ajax.tickets.php have been changed.

Couldn't unpick the query for this. After indexing all my tables, I gave up and produced a new MySQL view to query instead.

I then added a new find2() function into class.search.php. The SQL for the view is at the top in comments.

I also fixed a bug for date ranged searches in ajax.tickets.php. Start and end dates were being set as the same.

I'm not suggesting my view approach be merged directly, but might inform how you address this issue.

I have reduced query time from 30+ seconds (and a potential MySQL server take down) to around 0.14 seconds.