### PR TITLE
Pass data to the callabale by reference

### DIFF
--- a/include/class.signal.php
+++ b/include/class.signal.php
@@ -95,7 +95,7 @@ class Signal {
                 continue;
             elseif ($check && !call_user_func_array($check, array($object, $data)))
                 continue;
-            call_user_func_array($callable, array($object, $data));
+            call_user_func_array($callable, array($object, &$data));
         }
     }
 }


### PR DESCRIPTION
When using call_user_func_array arguments should be passed by reference in order to allow callable receive them by reference (only defining callable to receive data by reference is not enough).