### PR TITLE
cli: Fix incorrect option parsing

### DIFF
--- a/setup/cli/modules/class.module.php
+++ b/setup/cli/modules/class.module.php
@@ -265,7 +265,7 @@ class Module {
                 continue;
             }
             // Allow multiple simple args like -Dvt
-            if ($arg[0] == '-' && strlen($arg) > 2) {
+            if ($arg[0] == '-' && $arg[1] != '-' && strlen($arg) > 2) {
                 foreach (str_split(substr($arg, 2)) as $O)
                     array_unshift($argv, "-{$O}");
                 $arg = substr($arg, 0, 2);

--- a/setup/cli/modules/deploy.php
+++ b/setup/cli/modules/deploy.php
@@ -202,7 +202,7 @@ class Deployment extends Unpacker {
             if ($dryrun)
                 continue;
             if (!is_dir(dirname($dst)))
-                mkdir(dirname($dst), 0751, true);
+                mkdir(dirname($dst), 0755, true);
             $this->copyFile($src, $dst, $hash, octdec($mode));
         }
     }

--- a/setup/cli/modules/unpack.php
+++ b/setup/cli/modules/unpack.php
@@ -173,7 +173,7 @@ class Unpacker extends Module {
                 if ($dryrun)
                     continue;
                 if (!is_dir($destination))
-                    mkdir($destination, 0751, true);
+                    mkdir($destination, 0755, true);
                 $this->copyFile($file, $target, $hash);
             }
         }


### PR DESCRIPTION
This fixes a regression in the option parsing where --setup would be interpreted as --setup -e -t -u -p

Also, some parts of osTicket, like internationalization and plugins need read access to a directory in order to get a list of installed plugins and language packs.

Fixes #2196