### PR TITLE
variable: The HTML balancing system urlencodes @href

### DIFF
--- a/include/class.variable.php
+++ b/include/class.variable.php
@@ -26,7 +26,7 @@ class VariableReplacer {
 
     var $errors;
 
-    function VariableReplacer($start_delim='%{', $end_delim='}') {
+    function VariableReplacer($start_delim='(?:%{|%%7B)', $end_delim='(?:}|%7D)') {
 
         $this->start_delim = $start_delim;
         $this->end_delim = $end_delim;
@@ -131,7 +131,8 @@ class VariableReplacer {
         $vars = array();
         foreach($result[0] as $k => $v) {
             if(isset($vars[$v])) continue;
-            $val=$this->_resolveVar($result[1][$k]);
+            // Format::html_balance() may urlencode() the contents here
+            $val=$this->_resolveVar(rawurldecode($result[1][$k]));
             if($val!==false)
                 $vars[$v] = $val;
         }


### PR DESCRIPTION
The DomDocument::saveHtml() method will properly urlencode() values in the a[@href] attributes when saving. This patch allows for the sanitization while also allowing the variable replacement system to work properly with the sanitized values.

Fixes #2201