### PR TITLE
Fix tickets not opening when enabled

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1163,7 +1163,7 @@ class Ticket {
         // We're also checking autorespond flag because we don't want to
         // reopen closed tickets on auto-reply from end user. This is not to
         // confused with autorespond on new message setting
-        if ($autorespond && $this->isClosed() && $this->isReopenable()) {
+        if ($this->isClosed() && $this->isReopenable()) {
             $this->reopen();
 
             // Auto-assign to closing staff or last respondent


### PR DESCRIPTION
removing the $autorespond check in the logic fixes the issue of tickets not re-opening from Manage->Lists->Ticket Statuses->Items->Closed->Properties (Allow tickets on this status to be reopened by end users)