### PR TITLE
org: Fix matching of empty domain name

### DIFF
--- a/include/class.organization.php
+++ b/include/class.organization.php
@@ -166,6 +166,8 @@ class Organization extends OrganizationModel {
     }
 
     function isMappedToDomain($domain) {
+        if (!$domain || !$this->domain)
+            return false;
         foreach (explode(',', $this->domain) as $d) {
             $d = trim($d);
             if ($d[0] == '.') {
@@ -182,8 +184,12 @@ class Organization extends OrganizationModel {
     }
 
     static function forDomain($domain) {
-        foreach (static::objects()
-                ->filter(array('domain__contains'=>$domain)) as $org) {
+        if (!$domain)
+            return null;
+        foreach (static::objects()->filter(array(
+            'domain__gt'=>'',
+            'domain__contains'=>$domain
+        )) as $org) {
             if ($org->isMappedToDomain($domain)) {
                 return $org;
             }


### PR DESCRIPTION
If a user is created with an empty domain name (e.g. `<user@>`), then the user would be associated with the first organization without a main domain specified.

This patch ensures that the domain is not empty when making a match with an organization.