### PR TITLE
orgs: Add ticket sharing feature

### DIFF
--- a/include/class.client.php
+++ b/include/class.client.php
@@ -312,16 +312,29 @@ class  EndUser extends BaseAuthenticatedUser {
             'user_id' => $this->getId(),
         ));
 
-        // TODO: Implement UNION ALL support in the ORM
+        // Also add collaborator tickets to the list. This may seem ugly;
+        // but the general rule for SQL is that a single query can only use
+        // one index. Therefore, to scan two indexes (by user_id and
+        // thread.collaborators.user_id), we need two queries. A union will
+        // help out with that.
         $mine->union($collab->filter(array(
             'thread__collaborators__user_id' => $this->getId(),
             Q::not(array('user_id' => $this->getId()))
         )));
 
-        if ($this->getOrgId()) {
+        if ($orgid = $this->getOrgId()) {
+            // Also generate a separate query for all the tickets owned by
+            // either my organization or ones that I'm collaborating on
+            // which are not part of the organization.
             $myorg = clone $basic;
-            $myorg->filter(array('user__org_id' => $this->getOrgId()))
-                ->values('user__org_id');
+            $myorg->values('user__org_id');
+            $collab = clone $myorg;
+
+            $myorg->filter(array('user__org_id' => $orgid));
+            $myorg->union($collab->filter(array(
+                'thread__collaborators__user_id' => $this->getId(),
+                Q::not(array('user__org_id' => $orgid))
+            )));
         }
 
         return array('mine' => $mine, 'myorg' => $myorg);

--- a/include/class.nav.php
+++ b/include/class.nav.php
@@ -344,7 +344,7 @@ class UserNav {
                 $navs['new']=array('desc'=>__('Open a New Ticket'),'href'=>'open.php','title'=>'');
             if($user && $user->isValid()) {
                 if(!$user->isGuest()) {
-                    $navs['tickets']=array('desc'=>sprintf(__('Tickets (%d)'),$user->getNumTickets()),
+                    $navs['tickets']=array('desc'=>sprintf(__('Tickets (%d)'),$user->getNumTickets($user->canSeeOrgTickets())),
                                            'href'=>'tickets.php',
                                             'title'=>__('Show all tickets'));
                 } else {

--- a/include/class.organization.php
+++ b/include/class.organization.php
@@ -35,6 +35,9 @@ class OrganizationModel extends VerySimpleModel {
     const COLLAB_PRIMARY_CONTACT =  0x0002;
     const ASSIGN_AGENT_MANAGER =    0x0004;
 
+    const SHARE_PRIMARY_CONTACT =   0x0008;
+    const SHARE_EVERYBODY =         0x0010;
+
     const PERM_CREATE =     'org.create';
     const PERM_EDIT =       'org.edit';
     const PERM_DELETE =     'org.delete';
@@ -98,6 +101,14 @@ class OrganizationModel extends VerySimpleModel {
 
     function autoAssignAccountManager() {
         return $this->check(self::ASSIGN_AGENT_MANAGER);
+    }
+
+    function shareWithPrimaryContacts() {
+        return $this->check(self::SHARE_PRIMARY_CONTACT);
+    }
+
+    function shareWithEverybody() {
+        return $this->check(self::SHARE_EVERYBODY);
     }
 
     function getUpdateDate() {
@@ -206,6 +217,8 @@ implements TemplateVariable {
                 'collab-all-flag' => Organization::COLLAB_ALL_MEMBERS,
                 'collab-pc-flag' => Organization::COLLAB_PRIMARY_CONTACT,
                 'assign-am-flag' => Organization::ASSIGN_AGENT_MANAGER,
+                'sharing-primary' => Organization::SHARE_PRIMARY_CONTACT,
+                'sharing-all' => Organization::SHARE_EVERYBODY,
         ) as $ck=>$flag) {
             if ($this->check($flag))
                 $base[$ck] = true;
@@ -388,6 +401,16 @@ implements TemplateVariable {
                 'assign-am-flag' => Organization::ASSIGN_AGENT_MANAGER,
         ) as $ck=>$flag) {
             if ($vars[$ck])
+                $this->setStatus($flag);
+            else
+                $this->clearStatus($flag);
+        }
+
+        foreach (array(
+                'sharing-primary' => Organization::SHARE_PRIMARY_CONTACT,
+                'sharing-all' => Organization::SHARE_EVERYBODY,
+        ) as $ck=>$flag) {
+            if ($vars['sharing'] == $ck)
                 $this->setStatus($flag);
             else
                 $this->clearStatus($flag);

--- a/include/class.organization.php
+++ b/include/class.organization.php
@@ -450,7 +450,6 @@ implements TemplateVariable {
         if (!($org = Organization::lookup(array('name' => $vars['name'])))) {
             $org = Organization::create(array(
                 'name' => $vars['name'],
-                'created' => new SqlFunction('NOW'),
                 'updated' => new SqlFunction('NOW'),
             ));
             $org->save(true);
@@ -482,10 +481,17 @@ implements TemplateVariable {
         return $valid ? self::fromVars($form->getClean()) : null;
     }
 
+    static function create($vars=false) {
+        $org = parent::create($vars);
+
+        $org->created = new SqlFunction('NOW');
+        $org->setStatus(self::SHARE_PRIMARY_CONTACT);
+        return $org;
+    }
+
     // Custom create called by installer/upgrader to load initial data
     static function __create($ht, &$error=false) {
 
-        $ht['created'] = new SqlFunction('NOW');
         $org = Organization::create($ht);
         // Add dynamic data (if any)
         if ($ht['fields']) {

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -358,6 +358,18 @@ implements RestrictedAccess, Threadable {
         if ($user->getId() == $this->getUserId())
             return true;
 
+        // Organization
+        if ($user->canSeeOrgTickets()
+            && ($U = $this->getUser())
+            && ($U->getOrgId() == $user->getOrgId())
+        ) {
+            // The owner of this ticket is in the same organization as the
+            // user in question, and the organization is configured to allow
+            // the user in question to see other tickets in the
+            // organization.
+            return true;
+        }
+
         // Collaborator?
         // 1) If the user was authorized via this ticket.
         if ($user->getTicketId() == $this->getId()

--- a/include/class.user.php
+++ b/include/class.user.php
@@ -432,6 +432,12 @@ implements TemplateVariable {
         return (string) $account->getStatus();
     }
 
+    function canSeeOrgTickets() {
+        return $this->org && (
+                $this->org->shareWithEverybody()
+            || ($this->isPrimaryContact() && $this->org->shareWithPrimaryContacts()));
+    }
+
     function register($vars, &$errors) {
 
         // user already registered?

--- a/include/i18n/en_US/help/tips/org.yaml
+++ b/include/i18n/en_US/help/tips/org.yaml
@@ -1,0 +1,36 @@
+#
+# This is the view / management page for an organization in the user
+# directory
+#
+# Fields:
+# title - Shown in bold at the top of the popover window
+# content - The body of the help popover
+# links - List of links shows below the content
+#   title - Link title
+#   href - href of link (links starting with / are translated to the
+#       helpdesk installation path)
+#
+# The key names such as 'helpdesk_name' should not be translated as they
+# must match the HTML #ids put into the page template.
+#
+---
+org_sharing:
+    title: Ticket Sharing
+    content: >
+        <p>
+        Organization ticket sharing allows members access to tickets owned
+        by other members of the organization.
+        </p>
+        <p class="info-banner">
+        <i class="icon-info-sign"></i>
+        Collaborators always have access to tickets.
+        </p>
+
+email_domain:
+    title: Email Domain
+    content: >
+        Users can be automatically added to this organization based on their
+        email domain(s). Use the box below to enter one or more domains
+        separated by commas. For example, enter <code>mycompany.com</code>
+        for users with email addresses ending in @mycompany.com
+

--- a/include/staff/templates/org-profile.tmpl.php
+++ b/include/staff/templates/org-profile.tmpl.php
@@ -20,7 +20,7 @@ if ($info['error']) {
         ><i class="icon-fixed-width icon-cogs faded"></i>&nbsp;<?php
         echo __('Settings'); ?></a></li>
 </ul>
-<form method="post" class="org" action="<?php echo $action; ?>">
+<form method="post" class="org" action="<?php echo $action; ?>" data-tip-namespace="org">
 <div id="orgprofile_container">
 <div class="tab_content" id="profile" style="margin:5px;">
 <?php
@@ -111,7 +111,7 @@ if ($ticket && $ticket->getOwnerId() == $user->getId())
                         <option value="sharing-all" <?php echo $info['sharing-all'] ? 'selected="selected"' : '';
                             ?>><?php echo __('All members see all tickets'); ?></option>
                     </select>
-                    <i class="help-tip icon-question-sign" href="#org-sharing"></i>
+                    <i class="help-tip icon-question-sign" href="#org_sharing"></i>
                 </td>
             </tr>
             <tr>
@@ -140,6 +140,7 @@ if ($ticket && $ticket->getOwnerId() == $user->getId())
             <tr>
                 <th colspan="2">
                     <?php echo __('Email Domain'); ?>
+                    <i class="help-tip icon-question-sign" href="#email_domain"></i>
                 </th>
             </tr>
             <tr>

--- a/include/staff/templates/org-profile.tmpl.php
+++ b/include/staff/templates/org-profile.tmpl.php
@@ -98,6 +98,22 @@ if ($ticket && $ticket->getOwnerId() == $user->getId())
                     </select>
                     <br/><span class="error"><?php echo $errors['contacts']; ?></span>
                 </td>
+            </tr>
+            <tr>
+                <td width="180">
+                    <?php echo __('Ticket Sharing'); ?>:
+                </td>
+                <td>
+                    <select name="sharing">
+                        <option value=""><?php echo __('Disable'); ?></option>
+                        <option value="sharing-primary" <?php echo $info['sharing-primary'] ? 'selected="selected"' : '';
+                            ?>><?php echo __('Primary contacts see all tickets'); ?></option>
+                        <option value="sharing-all" <?php echo $info['sharing-all'] ? 'selected="selected"' : '';
+                            ?>><?php echo __('All members see all tickets'); ?></option>
+                    </select>
+                    <i class="help-tip icon-question-sign" href="#org-sharing"></i>
+                </td>
+            </tr>
             <tr>
                 <th colspan="2">
                     <?php echo __('Automated Collaboration'); ?>:
@@ -123,7 +139,7 @@ if ($ticket && $ticket->getOwnerId() == $user->getId())
             </tr>
             <tr>
                 <th colspan="2">
-                    <?php echo __('Main Domain'); ?>
+                    <?php echo __('Email Domain'); ?>
                 </th>
             </tr>
             <tr>

--- a/tickets.php
+++ b/tickets.php
@@ -128,7 +128,7 @@ if($ticket && $ticket->checkUserAccess($thisclient)) {
     }
     else
         $inc='view.inc.php';
-} elseif($thisclient->getNumTickets()) {
+} elseif($thisclient->getNumTickets($thisclient->canSeeOrgTickets())) {
     $inc='tickets.inc.php';
 } else {
     $nav->setActiveNav('new');


### PR DESCRIPTION
This feature allows (by option) an organization to allow its members to see tickets from other members. It can be used beside or instead of the automated collaboration feature. Now, collaborators retain access to tickets on which they participate; however, sharing can be used to enable access to other tickets owned by their organization.

<img width="636" alt="screen shot 2015-08-12 at 8 46 31 am" src="https://cloud.githubusercontent.com/assets/672074/9225379/a8a77922-40ce-11e5-9b23-055c03ab3a5f.png">
