### PR TITLE
Changed logo displays on save

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -124,6 +124,7 @@ class Config {
             return false;
 
         $setting['value'] = $value;
+        $setting['updated'] = Misc::dbtime();
         return true;
     }
 

--- a/include/staff/header.inc.php
+++ b/include/staff/header.inc.php
@@ -70,7 +70,7 @@ if ($lang) {
         </p>
         <a href="index.php" class="no-pjax" id="logo">
             <span class="valign-helper"></span>
-            <img src="logo.php" alt="osTicket &mdash; <?php echo __('Customer Support System'); ?>"/>
+            <img src="logo.php?<?php echo strtotime($cfg->lastModified('staff_logo_id')); ?>" alt="osTicket &mdash; <?php echo __('Customer Support System'); ?>"/>
         </a>
     </div>
     <div id="pjax-container" class="<?php if ($_POST) echo 'no-pjax'; ?>">


### PR DESCRIPTION
This will break the browser cache and refresh the selected logo on save.

The default logo displayed on page.
![logo-default](https://cloud.githubusercontent.com/assets/8247872/9387790/d283b6ac-4727-11e5-9c5f-9448c87b53d1.png)

Custom logo is selected and on save immediately displays selected logo in the header.
![logoselected](https://cloud.githubusercontent.com/assets/8247872/9387791/d2862112-4727-11e5-84ff-bad10c3bb409.png)

Custom logo is displayed in the header after save.
![logo-changed](https://cloud.githubusercontent.com/assets/8247872/9387789/d28171e4-4727-11e5-9556-b6dbbd5ffd4c.png)

### Outstanding
* After the custom logo is saved selecting the default logo again and saving does NOT change on save. It does change on refresh.