### PR TITLE
tickets: Fix subject display for non text fields

### DIFF
--- a/assets/default/css/theme.css
+++ b/assets/default/css/theme.css
@@ -801,7 +801,6 @@ label.required, span.required {
   border: 1px solid #aaa;
   border-left: none;
   border-bottom: none;
-  table-layout: fixed;
 }
 #ticketTable caption {
   padding: 5px;

--- a/assets/default/css/theme.css
+++ b/assets/default/css/theme.css
@@ -115,15 +115,16 @@ fieldset {
   padding: 0;
 }
 /* Typography */
-a {
+a, .link {
   color: #0072bc;
   text-decoration: none;
   display: inline-block;
   margin-bottom: 1px;
 }
-a:hover {
+a:hover, .link:hover {
     border-bottom: 1px dotted #0072bc;
     margin-bottom: 0;
+    cursor: pointer;
 }
 h1 {
   color: #00AEEF;

--- a/include/client/tickets.inc.php
+++ b/include/client/tickets.inc.php
@@ -225,7 +225,7 @@ if ($closedTickets) {?>
                 <td>&nbsp;<?php echo Format::date($T['created']); ?></td>
                 <td>&nbsp;<?php echo $status; ?></td>
                 <td>
-                    <div style="max-height: 1.2em" class="link truncate" href="tickets.php?id=<?php echo $T['ticket_id']; ?>"><?php echo $subject; ?></div>
+                    <div style="max-height: 1.2em; max-width: 320px;" class="link truncate" href="tickets.php?id=<?php echo $T['ticket_id']; ?>"><?php echo $subject; ?></div>
                 </td>
                 <td>&nbsp;<span class="truncate"><?php echo $dept; ?></span></td>
             </tr>

--- a/include/client/tickets.inc.php
+++ b/include/client/tickets.inc.php
@@ -225,7 +225,7 @@ if ($closedTickets) {?>
                 <td>&nbsp;<?php echo Format::date($T['created']); ?></td>
                 <td>&nbsp;<?php echo $status; ?></td>
                 <td>
-                    <a class="truncate" href="tickets.php?id=<?php echo $T['ticket_id']; ?>"><?php echo $subject; ?></a>
+                    <div style="max-height: 1.2em" class="link truncate" href="tickets.php?id=<?php echo $T['ticket_id']; ?>"><?php echo $subject; ?></div>
                 </td>
                 <td>&nbsp;<span class="truncate"><?php echo $dept; ?></span></td>
             </tr>

--- a/include/client/view.inc.php
+++ b/include/client/view.inc.php
@@ -32,7 +32,10 @@ if ($thisclient && $thisclient->isGuest()
         <td colspan="2" width="100%">
             <h1>
                 <a href="tickets.php?id=<?php echo $ticket->getId(); ?>" title="<?php echo __('Reload'); ?>"><i class="refresh icon-refresh"></i></a>
-                <b><?php echo Format::htmlchars($ticket->getSubject()); ?></b>
+                <b>
+                <?php $subject_field = TicketForm::getInstance()->getField('subject');
+                    echo $subject_field->display($ticket->getSubject()); ?>
+                </b>
                 <small>#<?php echo $ticket->getNumber(); ?></small>
 <div class="pull-right">
     <a class="action-button" href="tickets.php?a=print&id=<?php
@@ -95,32 +98,37 @@ if ($thisclient && $thisclient->isGuest()
         <td colspan="2">
 <!-- Custom Data -->
 <?php
-foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
+$sections = array();
+foreach (DynamicFormEntry::forTicket($ticket->getId()) as $i=>$form) {
     // Skip core fields shown earlier in the ticket view
     $answers = $form->getAnswers()->exclude(Q::any(array(
         'field__flags__hasbit' => DynamicFormField::FLAG_EXT_STORED,
         'field__name__in' => array('subject', 'priority'),
         Q::not(array('field__flags__hasbit' => DynamicFormField::FLAG_CLIENT_VIEW)),
     )));
-    if (count($answers) == 0)
-        continue;
+    // Skip display of forms without any answers
+    foreach ($answers as $j=>$a) {
+        if ($v = $a->display())
+            $sections[$i][$j] = array($v, $a);
+    }
+}
+foreach ($sections as $i=>$answers) {
     ?>
         <table class="custom-data" cellspacing="0" cellpadding="4" width="100%" border="0">
         <tr><td colspan="2" class="headline flush-left"><?php echo $form->getTitle(); ?></th></tr>
-        <?php foreach($answers as $a) {
-            if (!($v = $a->display())) continue; ?>
-            <tr>
-                <th><?php
-    echo $a->getField()->get('label');
-                ?>:</th>
-                <td><?php
-    echo $v;
-                ?></td>
-            </tr>
-            <?php } ?>
+<?php foreach ($answers as $A) {
+    list($v, $a) = $A; ?>
+        <tr>
+            <th><?php
+echo $a->getField()->get('label');
+            ?>:</th>
+            <td><?php
+echo $v;
+            ?></td>
+        </tr>
+<?php } ?>
         </table>
     <?php
-    $idx++;
 } ?>
     </td>
 </tr>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -201,7 +201,8 @@ if($ticket->isOverdue())
 </div>
 <div class="clear tixTitle has_bottom_border">
     <h3>
-    <?php echo Format::htmlchars($ticket->getSubject()); ?>
+    <?php $subject_field = TicketForm::getInstance()->getField('subject');
+        echo $subject_field->display($ticket->getSubject()); ?>
     </h3>
 </div>
 <table class="ticket_info" cellspacing="0" cellpadding="0" width="940" border="0">

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -472,8 +472,7 @@ return false;">
                     data-preview="#tickets/<?php echo $T['ticket_id']; ?>/preview"
                     ><?php echo $tid; ?></a></td>
                 <td align="center" nowrap><?php echo Format::datetime($T[$date_col ?: 'lastupdate']) ?: $date_fallback; ?></td>
-                <td><a <?php if ($flag) { ?> class="Icon <?php echo $flag; ?>Ticket" title="<?php echo ucfirst($flag); ?> Ticket" <?php } ?>
-                    style="max-width: <?php
+                <td><div style="max-width: <?php
                     $base = 280;
                     // Make room for the paperclip and some extra
                     if ($T['attachment_count']) $base -= 18;
@@ -481,9 +480,10 @@ return false;">
                     if ($threadcount > 1) $base -= 20 + ((int) log($threadcount, 10) + 1) * 8;
                     // Make room for overdue flag and friends
                     if ($flag) $base -= 20;
-                    echo $base; ?>px;"
-                    href="tickets.php?id=<?php echo $T['ticket_id']; ?>"><span
-                    class="truncate"><?php echo $subject; ?></span></a>
+                    echo $base; ?>px; max-height: 1.2em"
+                    class="<?php if ($flag) { ?>Icon <?php echo $flag; ?>Ticket <?php } ?>link truncate"
+                    <?php if ($flag) { ?> title="<?php echo ucfirst($flag); ?> Ticket" <?php } ?>
+                    href="tickets.php?id=<?php echo $T['ticket_id']; ?>"><?php echo $subject; ?></div>
 <?php               if ($T['attachment_count'])
                         echo '<i class="small icon-paperclip icon-flip-horizontal" data-toggle="tooltip" title="'
                             .$T['attachment_count'].'"></i>';

--- a/js/osticket.js
+++ b/js/osticket.js
@@ -220,3 +220,11 @@ $(document).on('submit', 'form', function() {
         $e.val(year+'-'+month+'-'+day);
     });
 });
+
+$(document).on('click', '.link:not(a):not(.button)', function(event) {
+  var $e = $(event.currentTarget);
+  $('<a>').prop({href: $e.attr('href'), 'class': $e.attr('class')})
+    .hide()
+    .insertBefore($e)
+    .get(0).click(event);
+});

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -13,15 +13,16 @@ body, html {
     padding:0;
 }
 
-.button.link,
+.link,
 a {
     color:#184E81;
     text-decoration:none;
     display: inline-block;
 }
 
-a:hover, .button.link:hover {
+a:hover, .link:hover {
     text-decoration: underline;
+    cursor: pointer;
 }
 
 #nav a:hover,

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -1055,6 +1055,14 @@ if ($.support.pjax) {
   })
 }
 
+$(document).on('click', '.link:not(a):not(.button)', function(event) {
+  var $e = $(event.currentTarget);
+  $('<a>').attr({href: $e.attr('href'), 'class': $e.attr('class')})
+    .hide()
+    .insertBefore($e)
+    .get(0).click(event);
+});
+
 // Quick-Add dialogs
 $(document).on('change', 'select[data-quick-add]', function() {
     var $select = $(this),


### PR DESCRIPTION
If the subject field is something crazy, such as an HTML field, ensure that the layout of the ticket queue is preserved and properly truncated. Furthermore, ensure that the HTML is properly rendered on the client and staff ticket view pages.