### PR TITLE
forms: Fix search by datetime fields

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -321,8 +321,7 @@ class DynamicForm extends VerySimpleModel {
         $f = $answer->getField();
         $name = $f->get('name') ? $f->get('name')
             : 'field_'.$f->get('id');
-        $fields = sprintf('`%s`=', $name) . db_input(
-            implode(',', $answer->getSearchKeys()));
+        $fields = sprintf('`%s`=', $name) . db_input($answer->getSearchKeys());
         $sql = 'INSERT INTO `'.$cdata['table'].'` SET '.$fields
             . sprintf(', `%s`= %s',
                     $cdata['object_id'],
@@ -533,8 +532,7 @@ class TicketForm extends DynamicForm {
             return;
 
         $name = $f->get('name') ?: ('field_'.$f->get('id'));
-        $fields = sprintf('`%s`=', $name) . db_input(
-            implode(',', $answer->getSearchKeys()));
+        $fields = sprintf('`%s`=', $name) . db_input($answer->getSearchKeys());
         $sql = 'INSERT INTO `'.TABLE_PREFIX.'ticket__cdata` SET '.$fields
             .', `ticket_id`='.db_input($answer->getEntry()->get('object_id'))
             .' ON DUPLICATE KEY UPDATE '.$fields;
@@ -1443,14 +1441,7 @@ class DynamicFormEntryAnswer extends VerySimpleModel {
     }
 
     function getSearchKeys() {
-        $val = $this->getField()->to_php(
-            $this->get('value'), $this->get('value_id'));
-        if (is_array($val))
-            return array_keys($val);
-        elseif (is_object($val) && method_exists($val, 'getId'))
-            return array($val->getId());
-
-        return array($val);
+        return implode(',', (array) $this->getField()->getKeys($this->getValue()));
     }
 
     function asVar() {
@@ -1568,6 +1559,14 @@ class SelectionField extends FormField {
         // Don't set the ID here as multiselect prevents using exactly one
         // ID value. Instead, stick with the JSON value only.
         return $value;
+    }
+
+    function getKeys($value) {
+        if (!is_array($value))
+            $value = $this->getChoice($value);
+        if (is_array($value))
+            return implode(', ', array_keys($value));
+        return (string) $value;
     }
 
     // PHP 5.4 Move this to a trait

--- a/include/class.forms.php
+++ b/include/class.forms.php
@@ -1891,7 +1891,7 @@ class DatetimeField extends FormField {
         $name = $name ?: $this->get('name');
         $config = $this->getConfiguration();
         $value = is_int($value)
-            ? DateTime::createFromFormat('U', !$config['gmt'] ? Misc::dbtime($value) : $value) ?: $value
+            ? DateTime::createFromFormat('U', !$config['gmt'] ? Misc::gmtime($value) : $value) ?: $value
             : $value;
         switch ($method) {
         case 'equal':
@@ -1915,7 +1915,8 @@ class DatetimeField extends FormField {
         case 'between':
             foreach (array('left', 'right') as $side) {
                 $value[$side] = is_int($value[$side])
-                    ? DateTime::createFromFormat('U', !$config['gmt'] ? Misc::dbtime($value[$side]) : $value[$side]) ?: $value[$side]
+                    ? DateTime::createFromFormat('U', !$config['gmt']
+                        ? Misc::gmtime($value[$side]) : $value[$side]) ?: $value[$side]
                     : $value[$side];
             }
             return new Q(array(
@@ -1923,14 +1924,16 @@ class DatetimeField extends FormField {
                 "{$name}__lte" => $value['right'],
             ));
         case 'ndaysago':
+            $now = Misc::gmtime();
             return new Q(array(
-                "{$name}__lt" => SqlFunction::NOW(),
-                "{$name}__gte" => SqlExpression::minus(SqlFunction::NOW(), SqlInterval::DAY($value['until'])),
+                "{$name}__lt" => $now,
+                "{$name}__gte" => SqlExpression::minus($now, SqlInterval::DAY($value['until'])),
             ));
         case 'ndays':
+            $now = Misc::gmtime();
             return new Q(array(
-                "{$name}__gt" => SqlFunction::NOW(),
-                "{$name}__lte" => SqlExpression::plus(SqlFunction::NOW(), SqlInterval::DAY($value['until'])),
+                "{$name}__gt" => $now,
+                "{$name}__lte" => SqlExpression::plus($now, SqlInterval::DAY($value['until'])),
             ));
         default:
             return parent::getSearchQ($method, $value, $name);

--- a/include/class.misc.php
+++ b/include/class.misc.php
@@ -127,8 +127,15 @@ class Misc {
     }
 
     /*Helper get GM time based on timezone offset*/
-    function gmtime() {
-        return time()-date('Z');
+    function gmtime($time=false, $user=false) {
+        global $cfg;
+
+        $tz = new DateTimeZone($user ? $cfg->getDbTimezone($user) : 'UTC');
+        if (!($time = new DateTime($time ?: 'now'))) {
+            // Old standard
+            return time() - date('Z');
+        }
+        return $time->getTimestamp() - $tz->getOffset($time);
     }
 
     /* Needed because of PHP 4 support */
@@ -190,7 +197,7 @@ class Misc {
                 $sel=($hr==$i && $min==$minute)?'selected="selected"':'';
                 $_minute=str_pad($minute, 2, '0',STR_PAD_LEFT);
                 $_hour=str_pad($i, 2, '0',STR_PAD_LEFT);
-                $disp = Format::time($i*3600 + $minute*60 + 1, false, false, 'UTC');
+                $disp = Format::time($i*3600 + $minute*60 + 1);
                 echo sprintf('<option value="%s:%s" %s>%s</option>',$_hour,$_minute,$sel,$disp);
             }
         }

--- a/include/staff/ticket-edit.inc.php
+++ b/include/staff/ticket-edit.inc.php
@@ -133,7 +133,8 @@ if ($_POST)
                 echo Misc::timeDropdown($hr, $min, 'time');
                 ?>
                 &nbsp;<font class="error">&nbsp;<?php echo $errors['duedate']; ?>&nbsp;<?php echo $errors['time']; ?></font>
-                <em><?php echo __('Time is based on your time zone');?> (GMT <?php echo Format::date(false, false, 'ZZZ'); ?>)</em>
+                <em><?php echo __('Time is based on your time zone');?>
+                    (<?php echo $cfg->getTimezone($thisstaff); ?>)</em>
             </td>
         </tr>
     </tbody>

--- a/include/upgrader/streams/core/0d6099a6-98ad7d55.patch.sql
+++ b/include/upgrader/streams/core/0d6099a6-98ad7d55.patch.sql
@@ -52,6 +52,15 @@ UPDATE `%TABLE_PREFIX%form_field` A1
   SET A1.`flags` = A1.`flags` | 0x00002
   WHERE A2.`type` = 'T' AND A1.`name` = 'message';
 
+-- Change storage type for `DatetimeField` values to Y-m-d format
+UPDATE `%TABLE_PREFIX%form_entry_values` A1
+  JOIN `%TABLE_PREFIX%form_field` A2 ON (A2.`id` = A1.`field_id`)
+  SET A1.`value` = DATE_FORMAT(FROM_UNIXTIME(A1.`value`), '%Y-%m-%d %H:%i:%s')
+  WHERE A2.`type` = 'datetime';
+
+-- Updates should happen in the %cdata tables too; however, those are more
+-- complex and the tables are being dropped anyway
+
 -- Finished with patch
 UPDATE `%TABLE_PREFIX%config`
     SET `value` = '98ad7d550c26ac44340350912296e673'

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -406,6 +406,7 @@ if($stats['overdue']) {
 
 if (isset($_SESSION['advsearch'])) {
     // XXX: De-duplicate and simplify this code
+    TicketForm::ensureDynamicDataView();
     $search = SavedSearch::create();
     $form = $search->getFormFromSession('advsearch');
     $tickets = TicketModel::objects();


### PR DESCRIPTION
This changes the storage model for datetime fields and stores them in the same format as the MySQL `datetime` column type. This allows for the searching code to be consistent when searching the database for datetime custom form entry data.

It also addresses and inconsistency in the forms code, where the PHP value of form fields was stored in the %cdata tables—instead of the normal database version. This code includes a FormField::getKeys() method to deal with multi-entry choice fields.