### PR TITLE
search: Improve typeahead results and performance

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -61,6 +61,7 @@ class TicketsAjaxAPI extends AjaxController {
                     'tickets' => new SqlCode('1'),
                     '__relevance__' => new SqlCode(1)
                 ))
+                ->filter($visibility)
                 ->filter(array('number__startswith' => $q))
                 ->limit($limit)
                 ->union($hits);

--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -26,46 +26,6 @@ class TicketsAjaxAPI extends AjaxController {
     function lookup() {
         global $thisstaff;
 
-        if(!is_numeric($_REQUEST['q']))
-            return self::lookupByEmail();
-
-
-        $limit = isset($_REQUEST['limit']) ? (int) $_REQUEST['limit']:25;
-        $tickets=array();
-
-        $visibility = Q::any(array(
-            'staff_id' => $thisstaff->getId(),
-            'team_id__in' => $thisstaff->teams->values_flat('team_id'),
-        ));
-        if (!$thisstaff->showAssignedOnly() && ($depts=$thisstaff->getDepts())) {
-            $visibility->add(array('dept_id__in' => $depts));
-        }
-
-
-        $hits = TicketModel::objects()
-            ->filter(Q::any(array(
-                'number__startswith' => $_REQUEST['q'],
-            )))
-            ->filter($visibility)
-            ->values('number', 'user__emails__address')
-            ->annotate(array('tickets' => SqlAggregate::COUNT('ticket_id')))
-            ->order_by('-created')
-            ->limit($limit);
-
-        foreach ($hits as $T) {
-            $tickets[] = array('id'=>$T['number'], 'value'=>$T['number'],
-                'info'=>"{$T['number']} — {$T['user__emails__address']}",
-                'matches'=>$_REQUEST['q']);
-        }
-        if (!$tickets)
-            return self::lookupByEmail();
-
-        return $this->json_encode($tickets);
-    }
-
-    function lookupByEmail() {
-        global $thisstaff;
-
 
         $limit = isset($_REQUEST['limit']) ? (int) $_REQUEST['limit']:25;
         $tickets=array();
@@ -80,8 +40,10 @@ class TicketsAjaxAPI extends AjaxController {
 
         $hits = TicketModel::objects()
             ->filter($visibility)
-            ->values('user__emails__address')
-            ->annotate(array('tickets' => SqlAggregate::COUNT('ticket_id')))
+            ->values('user__default_email__address')
+            ->annotate(array(
+                'number' => new SqlCode('null'),
+                'tickets' => SqlAggregate::COUNT('ticket_id', true)))
             ->limit($limit);
 
         $q = $_REQUEST['q'];
@@ -92,17 +54,35 @@ class TicketsAjaxAPI extends AjaxController {
         $hits = $ost->searcher->find($q, $hits)
             ->order_by(new SqlCode('__relevance__'), QuerySet::DESC);
 
-        if (!count($hits) && $q[strlen($q)-1] != '*') {
+        if (preg_match('/\d{2,}[^*]/', $q, $T = array())) {
+            $hits = TicketModel::objects()
+                ->values('user__default_email__address', 'number')
+                ->annotate(array(
+                    'tickets' => new SqlCode('1'),
+                    '__relevance__' => new SqlCode(1)
+                ))
+                ->filter(array('number__startswith' => $q))
+                ->limit($limit)
+                ->union($hits);
+        }
+        elseif (!count($hits) && $q[strlen($q)-1] != '*') {
             // Do wild-card fulltext search
             $_REQUEST['q'] = $q.'*';
-            return $this->lookupByEmail();
+            return $this->lookup();
         }
 
         foreach ($hits as $T) {
-            $email = $T['user__emails__address'];
+            $email = $T['user__default_email__address'];
             $count = $T['tickets'];
-            $tickets[] = array('email'=>$email, 'value'=>$email,
-                'info'=>"$email ($count)", 'matches'=>$_REQUEST['q']);
+            if ($T['number']) {
+                $tickets[] = array('id'=>$T['number'], 'value'=>$T['number'],
+                    'info'=>"{$T['number']} — {$email}",
+                    'matches'=>$_REQUEST['q']);
+            }
+            else {
+                $tickets[] = array('email'=>$email, 'value'=>$email,
+                    'info'=>"$email ($count)", 'matches'=>$_REQUEST['q']);
+            }
         }
 
         return $this->json_encode($tickets);

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -41,7 +41,7 @@ abstract class SearchBackend {
     );
 
     abstract function update($model, $id, $content, $new=false, $attrs=array());
-    abstract function find($query, QuerySet $criteria);
+    abstract function find($query, QuerySet $criteria, $addRelevance=true);
 
     static function register($backend=false) {
         $backend = $backend ?: get_called_class();
@@ -76,9 +76,9 @@ class SearchInterface {
         $this->bootstrap();
     }
 
-    function find($query, QuerySet $criteria) {
+    function find($query, QuerySet $criteria, $addRelevance=true) {
         $query = Format::searchable($query);
-        return $this->backend->find($query, $criteria);
+        return $this->backend->find($query, $criteria, $addRelevance);
     }
 
     function update($model, $id, $content, $new=false, $attrs=array()) {
@@ -324,7 +324,7 @@ class MysqlSearchBackend extends SearchBackend {
         return implode(' ', $results);
     }
 
-    function find($query, QuerySet $criteria) {
+    function find($query, QuerySet $criteria, $addRelevance=true) {
         global $thisstaff;
 
         $criteria = clone $criteria;
@@ -343,10 +343,14 @@ class MysqlSearchBackend extends SearchBackend {
         switch ($criteria->model) {
         case false:
         case 'TicketModel':
+            if ($addRelevance) {
+                $criteria = $criteria->extra(array(
+                    'select' => array(
+                        '__relevance__' => 'Z1.`relevance`',
+                    ),
+                ));
+            }
             $criteria->extra(array(
-                'select' => array(
-                    '__relevance__' => 'Z1.`relevance`',
-                ),
                 'tables' => array(
                     str_replace(array(':', '{}'), array(TABLE_PREFIX, $search),
                     "(SELECT COALESCE(Z3.`object_id`, Z5.`ticket_id`, Z8.`ticket_id`) as `ticket_id`, {} AS `relevance` FROM `:_search` Z1 LEFT JOIN `:thread_entry` Z2 ON (Z1.`object_type` = 'H' AND Z1.`object_id` = Z2.`id`) LEFT JOIN `:thread` Z3 ON (Z2.`thread_id` = Z3.`id` AND Z3.`object_type` = 'T') LEFT JOIN `:ticket` Z5 ON (Z1.`object_type` = 'T' AND Z1.`object_id` = Z5.`ticket_id`) LEFT JOIN `:user` Z6 ON (Z6.`id` = Z1.`object_id` and Z1.`object_type` = 'U') LEFT JOIN `:organization` Z7 ON (Z7.`id` = Z1.`object_id` AND Z7.`id` = Z6.`org_id` AND Z1.`object_type` = 'O') LEFT JOIN :ticket Z8 ON (Z8.`user_id` = Z6.`id`) WHERE {}) Z1"),

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -1138,11 +1138,11 @@ class TicketFlagChoiceField extends ChoiceField {
 class TicketSourceChoiceField extends ChoiceField {
     function getChoices() {
         return array(
-            'w' => __('Web'),
-            'e' => __('Email'),
-            'p' => __('Phone'),
-            'a' => __('API'),
-            'o' => __('Other'),
+            'web' => __('Web'),
+            'email' => __('Email'),
+            'phone' => __('Phone'),
+            'api' => __('API'),
+            'other' => __('Other'),
         );
     }
 

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -87,7 +87,7 @@ case 'search':
                     'user__emails__address' => $_REQUEST['query'],
                 ));
             }
-            elseif (is_numeric($_REQUEST['query'])) {
+            elseif ($_REQUEST['query']) {
                 $tickets = $tickets->filter(array(
                     'number' => $_REQUEST['query'],
                 ));

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -110,6 +110,25 @@ case 'search':
         // Clear sticky search queue
         unset($_SESSION[$queue_key]);
         break;
+    }
+    // Apply user filter
+    elseif (isset($_GET['uid']) && ($user = User::lookup($_GET['uid']))) {
+        $tickets->filter(array('user__id'=>$_GET['uid']));
+        $results_type = sprintf('%s — %s', __('Search Results'),
+            $user->getName());
+        if (isset($_GET['status']))
+            $status = $_GET['status'];
+        // Don't apply normal open ticket
+        break;
+    }
+    elseif (isset($_GET['orgid']) && ($org = Organization::lookup($_GET['orgid']))) {
+        $tickets->filter(array('user__org_id'=>$_GET['orgid']));
+        $results_type = sprintf('%s — %s', __('Search Results'),
+            $org->getName());
+        if (isset($_GET['status']))
+            $status = $_GET['status'];
+        // Don't apply normal open ticket
+        break;
     } elseif (isset($_SESSION['advsearch'])) {
         $form = $search->getFormFromSession('advsearch');
         $tickets = $search->mangleQuerySet($tickets, $form);
@@ -122,21 +141,6 @@ case 'search':
                 break;
             }
         }
-        break;
-    }
-    // Apply user filter
-    elseif (isset($_GET['uid']) && ($user = User::lookup($_GET['uid']))) {
-        $tickets->filter(array('user__id'=>$_GET['uid']));
-        $results_type = sprintf('%s — %s', __('Search Results'),
-            $user->getName());
-        // Don't apply normal open ticket
-        break;
-    }
-    elseif (isset($_GET['orgid']) && ($org = Organization::lookup($_GET['orgid']))) {
-        $tickets->filter(array('user__org_id'=>$_GET['orgid']));
-        $results_type = sprintf('%s — %s', __('Search Results'),
-            $org->getName());
-        // Don't apply normal open ticket
         break;
     }
     // Fall-through and show open tickets

--- a/scp/js/bootstrap-typeahead.js
+++ b/scp/js/bootstrap-typeahead.js
@@ -158,9 +158,8 @@
   , highlighter: function (item) {
       if (!this.query)
           return item;
-      return item.replace(new RegExp('(' + this.query + ')', 'ig'), function ($1, match) {
-        return '<strong>' + match + '</strong>'
-      })
+      var exp = this.query.replace(/[.?*+^$[\]\\(){}|-]/g, "\\$&").replace(' ', '|')
+      return item.replace(new RegExp(exp, 'ig'), '<strong>$&</strong>')
     }
 
   , render: function (items) {

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -256,7 +256,7 @@ var scp_prep = function() {
         source: function (typeahead, query) {
             if (last_req) last_req.abort();
             var $el = this.$element;
-            var url = $el.data('url')+'?q='+query;
+            var url = $el.data('url')+'?q='+encodeURIComponent(query);
             last_req = $.ajax({
                 url: url,
                 dataType: 'json',

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -746,7 +746,7 @@ $.confirm = function(message, title, options) {
                 .append($('<input type="button" class="close"/>')
                     .attr('value', __('Cancel'))
                     .click(function() { hide(); })
-            )).append($('<span class="buttons pull-right">test</span>')
+            )).append($('<span class="buttons pull-right"></span>')
                 .append($('<input type="button"/>')
                     .attr('value', __('OK'))
                     .click(function() {  hide(); D.resolve(body.find('input').serializeArray()); })

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -37,9 +37,10 @@ if($_REQUEST['id']) {
 
 if ($_REQUEST['uid']) {
     $user = User::lookup($_REQUEST['uid']);
-} elseif (!$ticket) {
+}
+if (!$ticket) {
     $queue_key = sprintf('::Q:%s', ObjectModel::OBJECT_TYPE_TICKET);
-    $queue_name = strtolower($_GET['status'] ?: $_GET['a']); //Status is overloaded
+    $queue_name = strtolower($_GET['a'] ?: $_GET['status']); //Status is overloaded
     if (!$queue_name && isset($_SESSION[$queue_key]))
         $queue_name = $_SESSION[$queue_key];
 


### PR DESCRIPTION
This patch fixes the sticky queue system. For instance, performing an advanced search does not always end up serving the search results on the next request. A second click on the "Search" queue might be required to actually view the results..

The typeahead in the basic search uses full-text search, which is about 10x faster than the index and full-table scans previously employed. Numbers are treated as ticket numbers along with full text search. Hits on ticket numbers are preferred in the typeahead results automatically. 

Scrolling is employed in the typeahead rather than limiting at 8 hits. 25 hits are displayed at most.

Searching for email addresses can be confusing, and the at sign (@) is completely ignored by the full-text backend. However, using a few words rather than the email address is likely easier to type. For instance `jared osticket` is likely easier to type than the full email address anyway.