### PR TITLE
reduce memory usage when storing file in DB

### DIFF
--- a/include/class.file.php
+++ b/include/class.file.php
@@ -856,15 +856,14 @@ class AttachmentChunkedData extends FileStorageBackend {
 
     function write($what, $chunk_size=CHUNK_SIZE) {
         $offset=0;
-        $what = bin2hex($what);
         for (;;) {
-            $block = substr($what, $offset, $chunk_size*2);
+            $block = bin2hex(substr($what, $offset, $chunk_size));
             if (!$block) break;
             if (!db_query('REPLACE INTO '.FILE_CHUNK_TABLE
                     .' SET filedata=0x'.$block.', file_id='
                     .db_input($this->file->getId()).', chunk_id='.db_input($this->_chunk++)))
                 return false;
-            $offset += strlen($block);
+            $offset += strlen($block)/2;
         }
 
         return $this->_chunk;


### PR DESCRIPTION
When saving an attached file in the database, Passing the whole content of the file to bin2hex leads to allocating the memory for the whole hex encoded file while the binary content of the file is still in memory. This leads easily to Out of memory error on limited resources servers. Calling bin2hex on each chunk of the file greatly limits the memory usage.