### PR TITLE
Fix issues deploying with PHP 5.6

### DIFF
--- a/include/class.api.php
+++ b/include/class.api.php
@@ -196,7 +196,7 @@ class ApiController {
     function getRequest($format) {
         global $ost;
 
-        $input = $ost->is_cli()?'php://stdin':'php://input';
+        $input = osTicket::is_cli()?'php://stdin':'php://input';
 
         if (!($stream = @fopen($input, 'r')))
             $this->exerr(400, __("Unable to read request body"));

--- a/include/class.cli.php
+++ b/include/class.cli.php
@@ -232,14 +232,22 @@ class Module {
         die();
     }
 
-    function _run($module_name) {
+    function _run($module_name, $bootstrap=true) {
         $this->module_name = $module_name;
+        if ($bootstrap)
+            $this->bootstrap();
         $this->parseOptions();
         return $this->run($this->_args, $this->_options);
     }
 
     /* abstract */
     function run($args, $options) {
+    }
+
+    function bootstrap() {
+        Bootstrap::loadConfig();
+        Bootstrap::defineTables(TABLE_PREFIX);
+        Bootstrap::loadCode();
     }
 
     function fail($message) {

--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -498,7 +498,7 @@ class osTicket {
     }
 
     /* returns true if script is being executed via commandline */
-    function is_cli() {
+    static function is_cli() {
         return (!strcasecmp(substr(php_sapi_name(), 0, 3), 'cli')
                 || (!isset($_SERVER['REQUEST_METHOD']) &&
                     !isset($_SERVER['HTTP_HOST']))

--- a/include/cli/cli.inc.php
+++ b/include/cli/cli.inc.php
@@ -23,7 +23,4 @@ define('INC_DIR',dirname(__file__).'/../inc/'); //local include dir!
 
 require_once INCLUDE_DIR . "class.cli.php";
 
-Bootstrap::loadConfig();
-Bootstrap::defineTables(TABLE_PREFIX);
-Bootstrap::loadCode();
 Bootstrap::i18n_prep();

--- a/include/cli/modules/unpack.php
+++ b/include/cli/modules/unpack.php
@@ -215,6 +215,11 @@ class Unpacker extends Module {
         return $location = rtrim($INCLUDE_DIR, '/').'/';
     }
 
+    function bootstrap() {
+        // Don't load config and frieds as that will likely crash if not yet
+        // installed
+    }
+
     function run($args, $options) {
         $this->destination = $args['install-path'];
         if (!is_dir($this->destination))

--- a/manage.php
+++ b/manage.php
@@ -80,5 +80,4 @@ class Manager extends Module {
 }
 
 $manager = new Manager();
-$manager->parseOptions();
-$manager->_run(basename(__file__));
+$manager->_run(basename(__file__), false);


### PR DESCRIPTION
The new deployment system will crash from a repo without a config file because it always calls Bootstrap::loadConfig(), which will crash in none exists. Furthermore, calls to osTicket::is_cli() result in some garbage output which gets written to the deployed `bootstrap.php` where INCLUDE_DIR is defined.