### PR TITLE
Set encoding of attachment's filename to utf-8.

### DIFF
--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -386,7 +386,7 @@ class Mailer {
                 if ($attachment['file_id']
                         && ($file=AttachmentFile::lookup($attachment['file_id']))) {
                     $mime->addAttachment($file->getData(),
-                        $file->getType(), $file->getName(),false);
+                        $file->getType(), $file->getName(),false, 'base64', 'attachment', '', '', '', null, null, '', 'utf-8');
                 }
             }
         }


### PR DESCRIPTION
With default setting, the attachment's filename display incorrect for non-ascii text.
Set the parameter "$h_charset" for Mail_Mime::addAttachment() to 'utf-8' will fix it.

p.s. welcome to modify, if there is better way to fix it,  thanks~