### PR TITLE
Add option to use dept/agent name as FROM-NAME on replies

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -1136,6 +1136,7 @@ class OsticketConfig extends Config {
             'allow_pw_reset'=>isset($vars['allow_pw_reset'])?1:0,
             'pw_reset_window'=>$vars['pw_reset_window'],
             'agent_name_format'=>$vars['agent_name_format'],
+            'hide_staff_name'=>isset($vars['hide_staff_name']) ? 1 : 0,
             'agent_avatar'=>$vars['agent_avatar'],
         ));
     }
@@ -1207,7 +1208,6 @@ class OsticketConfig extends Config {
             'show_assigned_tickets'=>isset($vars['show_assigned_tickets'])?0:1,
             'show_answered_tickets'=>isset($vars['show_answered_tickets'])?0:1,
             'show_related_tickets'=>isset($vars['show_related_tickets'])?1:0,
-            'hide_staff_name'=>isset($vars['hide_staff_name'])?1:0,
             'allow_client_updates'=>isset($vars['allow_client_updates'])?1:0,
             'ticket_lock' => $vars['ticket_lock'],
         ));

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -66,10 +66,14 @@ class Mailer {
         $this->ht['from'] = $from;
     }
 
-    function getFromAddress() {
+    function getFromAddress($options=array()) {
 
-        if(!$this->ht['from'] && ($email=$this->getEmail()))
-            $this->ht['from'] =sprintf('"%s" <%s>', ($email->getName()?$email->getName():$email->getEmail()), $email->getEmail());
+        if (!$this->ht['from'] && ($email=$this->getEmail())) {
+            if (($name = $options['from_name'] ?: $email->getName()))
+                $this->ht['from'] =sprintf('"%s" <%s>', $name, $email->getEmail());
+            else
+                $this->ht['from'] =sprintf('<%s>', $email->getEmail());
+        }
 
         return $this->ht['from'];
     }
@@ -316,7 +320,7 @@ class Mailer {
         $subject = preg_replace("/(\r\n|\r|\n)/s",'', trim($subject));
 
         $headers = array (
-            'From' => $this->getFromAddress(),
+            'From' => $this->getFromAddress($options),
             'To' => $to,
             'Subject' => $subject,
             'Date'=> date('D, d M Y H:i:s O'),

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -282,6 +282,10 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
         return $this->default_signature_type;
     }
 
+    function getReplyFromNameType() {
+        return $this->default_from_name;
+    }
+
     function getDefaultPaperSize() {
         return $this->default_paper_size;
     }
@@ -621,6 +625,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
         $this->max_page_size = $vars['max_page_size'];
         $this->auto_refresh_rate = $vars['auto_refresh_rate'];
         $this->default_signature_type = $vars['default_signature_type'];
+        $this->default_from_name = $vars['default_from_name'];
         $this->default_paper_size = $vars['default_paper_size'];
         $this->lang = $vars['lang'];
         $this->onvacation = isset($vars['onvacation'])?1:0;

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1436,6 +1436,10 @@ implements RestrictedAccess, Threadable {
         $attachments = $cfg->emailAttachments()?$entry->getAttachments():array();
         $options = array('inreplyto' => $entry->getEmailMessageId(),
                          'thread' => $entry);
+
+        if ($vars['from_name'])
+            $options += array('from_name' => $vars['from_name']);
+
         foreach ($recipients as $recipient) {
             // Skip folks who have already been included on this part of
             // the conversation
@@ -2430,11 +2434,32 @@ implements RestrictedAccess, Threadable {
         $options = array();
         $email = $dept->getEmail();
 
+        $signature = $from_name = '';
         if ($thisstaff && $vars['signature']=='mine')
             $signature=$thisstaff->getSignature();
         elseif ($vars['signature']=='dept' && $dept->isPublic())
             $signature=$dept->getSignature();
-        else
+
+        if ($thisstaff && ($type=$thisstaff->getReplyFromNameType())) {
+            switch ($type) {
+                case 'mine':
+                    if (!$cfg->hideStaffName())
+                        $from_name = (string) $thisstaff->getName();
+                    break;
+                case 'dept':
+                    if ($dept->isPublic())
+                        $from_name = $dept->getName();
+                    break;
+                case 'email':
+                default:
+                    $from_name =  $email->getName();
+            }
+
+            if ($from_name)
+                $options += array('from_name' => $from_name);
+
+        }
+
             $signature='';
 
         $variables = array(
@@ -2443,7 +2468,7 @@ implements RestrictedAccess, Threadable {
             'staff' => $thisstaff,
             'poster' => $thisstaff
         );
-        $options = array(
+        $options += array(
             'inreplyto' => $response->getEmailMessageId(),
             'references' => $response->getEmailReferences(),
             'thread'=>$response
@@ -2463,7 +2488,9 @@ implements RestrictedAccess, Threadable {
 
         if ($vars['emailcollab']) {
             $this->notifyCollaborators($response,
-                array('signature' => $signature)
+                array(
+                    'signature' => $signature,
+                    'from_name' => $from_name)
             );
         }
         return $response;

--- a/include/i18n/en_US/help/tips/settings.agents.yaml
+++ b/include/i18n/en_US/help/tips/settings.agents.yaml
@@ -21,6 +21,12 @@ agent_name_format:
         Choose a format for Agents names throughout the system. Email templates
         will use it for names if no other format is specified.
 
+staff_identity_masking:
+    title: Staff Identity Masking
+    content: >
+        If enabled, this will hide the Agent’s name from the Client during any
+        communication.
+
 # Authentication settings
 password_reset:
     title: Password Expiration Policy

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -108,12 +108,6 @@ answered_tickets:
         will be included in the <span class="doc-desc-title">Open Tickets
         Queue</span>.
 
-staff_identity_masking:
-    title: Staff Identity Masking
-    content: >
-        If enabled, this will hide the Agent’s name from the Client during any
-        communication.
-
 ticket_attachment_settings:
     title: Ticket Thread Attachments
     content: >

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -196,9 +196,35 @@ if ($avatar->isChangeable()) { ?>
                 </select>
             </td>
         </tr>
+
+        <tr>
+            <td><?php echo __('Default From Name');?>:
+              <div class="faded"><?php echo __('From name to use when replying to a thread');?></div>
+            </td>
+            <td>
+                <select name="default_from_name">
+                  <?php
+                   $options=array(
+                           'email' => __("Email Address Name"),
+                           'dept' => sprintf(__("Department Name (%s)"),
+                               __('if public' /* This is used in 'Department's Name (>if public<)' */)),
+                           'mine' => __('My Name'));
+                  if ($cfg->hideStaffName())
+                    unset($options['mine']);
+
+                  foreach($options as $k=>$v) {
+                      echo sprintf('<option value="%s" %s>%s</option>',
+                                $k,($staff->default_from_name==$k)?'selected="selected"':'',$v);
+                  }
+                  ?>
+                </select>
+                <div class="error"><?php echo $errors['default_from_name']; ?></div>
+            </td>
+        </tr>
+
         <tr>
             <td><?php echo __('Default Signature');?>:
-              <div class="faded"><?php echo __('This can be selected when replying to a ticket');?></div>
+              <div class="faded"><?php echo __('This can be selected when replying to a thread');?></div>
             </td>
             <td>
                 <select name="default_signature_type">

--- a/include/staff/settings-agents.inc.php
+++ b/include/staff/settings-agents.inc.php
@@ -36,6 +36,14 @@ if (!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config
                         </td>
                     </tr>
                     <tr>
+                        <td><?php echo __('Agent Identity Masking'); ?>:</td>
+                        <td>
+                            <input type="checkbox" name="hide_staff_name" <?php echo $config['hide_staff_name']?'checked="checked"':''; ?>>
+                            <?php echo __("Hide agent's name on responses."); ?>
+                            <i class="help-tip icon-question-sign" href="#staff_identity_masking"></i>
+                        </td>
+                    </tr>
+                    <tr>
                         <td width="180"><?php echo __('Avatar Source'); ?>:</td>
                         <td>
                             <select name="agent_avatar">

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -204,14 +204,6 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
-            <td><?php echo __('Agent Identity Masking'); ?>:</td>
-            <td>
-                <input type="checkbox" name="hide_staff_name" <?php echo $config['hide_staff_name']?'checked="checked"':''; ?>>
-                <?php echo __("Hide agent's name on responses."); ?>
-                <i class="help-tip icon-question-sign" href="#staff_identity_masking"></i>
-            </td>
-        </tr>
-        <tr>
             <th colspan="2">
                 <em><b><?php echo __('Attachments');?></b>:  <?php echo __('Size and maximum uploads setting mainly apply to web tickets.');?></em>
             </th>


### PR DESCRIPTION
Enable the ability to optionally use/show the agent's full name, department's name or emails address name on responses/replies. Email address of the response would still be designated outgoing email address of the Department to which the ticket is assigned or the system default outgoing email.

* Agents can set the default FROM Name in Profile > Preference.
* Private department's name won't be used regardless of the setting.
* Agent's name won't be used if identity masking is enabled.

### Pending 
* [x] Move ``Agent Identity Masking`` from Settings > Tickets to Settings > Agents 
* [ ] Add DB patch to add ``default_from_name`` field or convert agent to use config table.