### PR TITLE
Fix several search related issues

### DIFF
--- a/include/ajax.orgs.php
+++ b/include/ajax.orgs.php
@@ -29,6 +29,9 @@ class OrgsAjaxAPI extends AjaxController {
         $q = $_REQUEST['q'];
         $limit = isset($_REQUEST['limit']) ? (int) $_REQUEST['limit']:25;
 
+        if (strlen($q) < 2)
+            return $this->encode(array());
+
         $orgs = Organization::objects()
             ->values_flat('id', 'name')
             ->limit($limit);

--- a/include/ajax.orgs.php
+++ b/include/ajax.orgs.php
@@ -38,7 +38,7 @@ class OrgsAjaxAPI extends AjaxController {
         $orgs->order_by(new SqlCode('__relevance__'), QuerySet::DESC)
             ->distinct('id');
 
-        if (!count($orgs) && substr($q, strlen($q)-1) != '*') {
+        if (!count($orgs) && preg_match('`\w$`u', $q)) {
             // Do wildcard full-text search
             $_REQUEST['q'] = $q."*";
             return $this->search($type);

--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -66,7 +66,7 @@ class TicketsAjaxAPI extends AjaxController {
                 ->limit($limit)
                 ->union($hits);
         }
-        elseif (!count($hits) && $q[strlen($q)-1] != '*') {
+        elseif (!count($hits) && preg_match('`\w$`u', $q)) {
             // Do wild-card fulltext search
             $_REQUEST['q'] = $q.'*';
             return $this->lookup();

--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -47,8 +47,9 @@ class TicketsAjaxAPI extends AjaxController {
             ->limit($limit);
 
         $q = $_REQUEST['q'];
-        // Drop at sign in email addresses
-        $q = str_replace('@', ' ', $q);
+
+        if (strlen($q) < 2)
+            return $this->encode(array());
 
         global $ost;
         $hits = $ost->searcher->find($q, $hits)

--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -55,7 +55,7 @@ class UsersAjaxAPI extends AjaxController {
             $users->order_by(new SqlCode('__relevance__'), QuerySet::DESC)
                 ->distinct('id');
 
-            if (!count($emails) && !count($users) && substr($q, strlen($q)-1) != '*') {
+            if (!count($emails) && !count($users) && preg_match('`\w$`u', $q)) {
                 // Do wildcard full-text search
                 $_REQUEST['q'] = $q."*";
                 return $this->search($type);

--- a/include/ajax.users.php
+++ b/include/ajax.users.php
@@ -34,6 +34,9 @@ class UsersAjaxAPI extends AjaxController {
         $users=array();
         $emails=array();
 
+        if (strlen($q) < 2)
+            return $this->encode(array());
+
         if (!$type || !strcasecmp($type, 'remote')) {
             foreach (AuthenticationBackend::searchUsers($q) as $u) {
                 $name = new UsersName(array('first' => $u['first'], 'last' => $u['last']));

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -376,7 +376,7 @@ class MysqlSearchBackend extends SearchBackend {
             $criteria->extra(array(
                 'tables' => array(
                     str_replace(array(':', '{}'), array(TABLE_PREFIX, $search),
-                    "(SELECT COALESCE(Z3.`object_id`, Z5.`ticket_id`, Z8.`ticket_id`) as `ticket_id`, {} AS `relevance` FROM `:_search` Z1 LEFT JOIN `:thread_entry` Z2 ON (Z1.`object_type` = 'H' AND Z1.`object_id` = Z2.`id`) LEFT JOIN `:thread` Z3 ON (Z2.`thread_id` = Z3.`id` AND Z3.`object_type` = 'T') LEFT JOIN `:ticket` Z5 ON (Z1.`object_type` = 'T' AND Z1.`object_id` = Z5.`ticket_id`) LEFT JOIN `:user` Z6 ON (Z6.`id` = Z1.`object_id` and Z1.`object_type` = 'U') LEFT JOIN `:organization` Z7 ON (Z7.`id` = Z1.`object_id` AND Z7.`id` = Z6.`org_id` AND Z1.`object_type` = 'O') LEFT JOIN :ticket Z8 ON (Z8.`user_id` = Z6.`id`) WHERE {}) Z1"),
+                    "(SELECT COALESCE(Z3.`object_id`, Z5.`ticket_id`, Z8.`ticket_id`) as `ticket_id`, SUM({}) AS `relevance` FROM `:_search` Z1 LEFT JOIN `:thread_entry` Z2 ON (Z1.`object_type` = 'H' AND Z1.`object_id` = Z2.`id`) LEFT JOIN `:thread` Z3 ON (Z2.`thread_id` = Z3.`id` AND Z3.`object_type` = 'T') LEFT JOIN `:ticket` Z5 ON (Z1.`object_type` = 'T' AND Z1.`object_id` = Z5.`ticket_id`) LEFT JOIN `:user` Z6 ON (Z6.`id` = Z1.`object_id` and Z1.`object_type` = 'U') LEFT JOIN `:organization` Z7 ON (Z7.`id` = Z1.`object_id` AND Z7.`id` = Z6.`org_id` AND Z1.`object_type` = 'O') LEFT JOIN :ticket Z8 ON (Z8.`user_id` = Z6.`id`) WHERE {} GROUP BY `ticket_id`) Z1"),
                 )
             ));
             $criteria->filter(array('ticket_id'=>new SqlCode('Z1.`ticket_id`')));

--- a/include/class.search.php
+++ b/include/class.search.php
@@ -327,6 +327,11 @@ class MysqlSearchBackend extends SearchBackend {
     function find($query, QuerySet $criteria, $addRelevance=true) {
         global $thisstaff;
 
+        // MySQL usually doesn't handle words shorter than three letters
+        // (except with special configuration)
+        if (strlen($query) < 3)
+            return $criteria;
+
         $criteria = clone $criteria;
 
         $mode = ' IN NATURAL LANGUAGE MODE';

--- a/include/client/tickets.inc.php
+++ b/include/client/tickets.inc.php
@@ -90,10 +90,10 @@ if ($thisclient->canSeeOrgTickets()) {
 
 // Perform basic search
 if ($settings['keywords']) {
-    $q = $settings['keywords'];
+    $q = trim($settings['keywords']);
     if (is_numeric($q)) {
         $tickets->filter(array('number__startswith'=>$q));
-    } else { //Deep search!
+    } elseif (strlen($q) > 2) { //Deep search!
         // Use the search engine to perform the search
         $tickets = $ost->searcher->find($q, $tickets);
     }

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -108,6 +108,7 @@ case 'search':
         }
         if (count($tickets) == 1) {
             // Redirect to ticket page
+            Http::redirect('tickets.php?id='.$tickets[0]->getId());
         }
         // Clear sticky search queue
         unset($_SESSION[$queue_key]);

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -100,7 +100,7 @@ case 'search':
                 // Do wildcard search if no hits
                 $__tickets = $ost->searcher->find($_REQUEST['query'].'*', $tickets);
             }
-            $tickets = $__tickets->distinct('ticket_id');
+            $tickets = $__tickets;
             $has_relevance = true;
         }
         if (count($tickets) == 1) {

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -94,11 +94,12 @@ case 'search':
             }
         }
         elseif ($_REQUEST['query']) {
+            $q = trim($_REQUEST['query']);
             // [Search] click, consider keywords
-            $__tickets = $ost->searcher->find($_REQUEST['query'], $tickets);
-            if (!count($__tickets)) {
+            $__tickets = $ost->searcher->find($q, $tickets);
+            if (!count($__tickets) && preg_match('`\w$`u', $q)) {
                 // Do wildcard search if no hits
-                $__tickets = $ost->searcher->find($_REQUEST['query'].'*', $tickets);
+                $__tickets = $ost->searcher->find($q.'*', $tickets);
             }
             $tickets = $__tickets;
             $has_relevance = true;

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -93,8 +93,10 @@ case 'search':
                 ));
             }
         }
-        elseif ($_REQUEST['query']) {
-            $q = trim($_REQUEST['query']);
+        elseif (isset($_REQUEST['query'])
+            && ($q = trim($_REQUEST['query']))
+            && strlen($q) > 2
+        ) {
             // [Search] click, consider keywords
             $__tickets = $ost->searcher->find($q, $tickets);
             if (!count($__tickets) && preg_match('`\w$`u', $q)) {


### PR DESCRIPTION
* Bubble search relevance from the sum of the relevance for all thread entries, users, organizations, and ticket metad-data when searching for tickets
* Only auto-promote to wildcard searches if the search query ends in a word char (letter or number)
* Only quote email addresses in BOOLEAN full-text mode. This allows for searching for partial email addresses
* Avoid using very short search queries for full-text searches
* If a full-text search results in one hit (e.g. search on ticket number), then redirect directly to the ticket view