### PR TITLE
End user avatar fix for #2557 #2580

### DIFF
--- a/assets/default/css/theme.css
+++ b/assets/default/css/theme.css
@@ -1064,7 +1064,7 @@ img.avatar {
 }
 .avatar > img.avatar {
     width: 100%;
-    height: 100%;
+    height: auto;
 }
 .thread-entry .header {
     padding: 8px 0.9em;


### PR DESCRIPTION
Older browser height fix for the end user avatar. Changing the height
100% property to height auto; corrects the avatar size on older
browsers, in this case Safari 5. The fix will keep the image from
stretching 100% for the end user.