### PR TITLE
Uploaded image preview fix

### DIFF
--- a/css/filedrop.css
+++ b/css/filedrop.css
@@ -25,6 +25,7 @@
     padding: 5px 10px 5px 20px;
     margin: 0;
     border-radius: 5px;
+    height:25px;
 }
 .rtl .filedrop .files .file {
     padding-left: 10px;
@@ -36,6 +37,10 @@
 .filedrop .files .file .filesize {
   margin: 0 1em;
   color: #999;
+}
+.filedrop .files .file > span {
+    padding:4px 0 0 0;
+    display:block;
 }
 .filedrop .files .file .upload-rate {
   margin: 0 10px;
@@ -53,8 +58,8 @@
 .filedrop .preview {
   width: auto;
   height: auto;
-  max-width: 60px;
-  max-height: 40px;
+  max-width: 100px;
+  max-height: 25px;
   display: inline-block;
   float: left;
   padding-right: 10px;


### PR DESCRIPTION
Sets a static height to the row since it truncates it shouldn’t have
any odd behavior. Content in the span is centered on the row and sets
image height to fit inside the row.

Before:
![screen shot 2015-10-02 at 4 28 22 pm](https://cloud.githubusercontent.com/assets/8247872/10258273/abd0596c-6922-11e5-8de0-57ba78f8e730.png)

After:
![screen shot 2015-10-02 at 4 14 59 pm](https://cloud.githubusercontent.com/assets/8247872/10258232/75b38eda-6922-11e5-8eb7-28dfc65b5300.png)
