### PR TITLE
locks: Exclude expired locks via constrain

### DIFF
--- a/include/staff/templates/tickets.tmpl.php
+++ b/include/staff/templates/tickets.tmpl.php
@@ -25,6 +25,11 @@ if (!$thisstaff->hasPerm(SearchBackend::PERM_EVERYTHING)) {
     $tickets->filter(Q::any($visibility));
 }
 
+
+$tickets->constrain(array('lock' => array(
+                'lock__expire__gt' => SqlFunction::NOW())));
+
+
 $tickets->annotate(array(
     'collab_count' => SqlAggregate::COUNT('thread__collaborators', true),
     'attachment_count' => SqlAggregate::COUNT(SqlCase::N()

--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -319,6 +319,11 @@ $tickets->annotate(array(
         ->aggregate(array('count' => SqlAggregate::COUNT('entries__id'))),
 ));
 
+
+// Make sure we're only getting active locks
+$tickets->constrain(array('lock' => array(
+                'lock__expire__gt' => SqlFunction::NOW())));
+
 ?>
 
 <!-- SEARCH FORM START -->


### PR DESCRIPTION
Fixes a bug where a lock icon is shown on tickets listing even when the lock in question is expired.