### PR TITLE
UI: Assignment alerts do NOT include teams

### DIFF
--- a/include/staff/settings-alerts.inc.php
+++ b/include/staff/settings-alerts.inc.php
@@ -123,7 +123,7 @@
         <tr>
             <td>
               <input type="checkbox" name="assigned_alert_staff" <?php echo
-              $config['assigned_alert_staff']?'checked':''; ?>> <?php echo __('Assigned Agent / Team'); ?>
+              $config['assigned_alert_staff']?'checked':''; ?>> <?php echo __('Assigned Agent'); ?>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
Hi guys,

had this issue in my mind from before my vacation. Someone over in the forum had the issue that even though he checked "Assigned Agent / Team" the team never got notified. After some research and a closer look I guess Neil found out that he needed to check "Team Lead" and/or "Team members" to enable alerts for the team as well.

So in this case the wording "Assigned Agent / Team" is a bit misleading and I suggest to change it to just "Assigned Agent" or whatever  you prefer ;)

Just made this pull request, so that you don't need to search long and it's (hopefully) easier to understand which "Assigned Agent / Team" is meant since it's there several times at the alert settings page.

Cheers,
Michael

PS: Also I don't know why the first line appears as "removed" and "added" ... didn't change anything here, but anyway, line 126 is the important one ;)