### PR TITLE
Provide the option to preselect a help topic

### DIFF
--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -11,7 +11,7 @@ $info=($_POST && $errors)?Format::htmlchars($_POST):$info;
 
 $form = null;
 if (!$info['topicId'])
-    $info['topicId'] = $cfg->getDefaultTopicId();
+    $info['topicId'] = isset($_GET['ht']) ? $_GET['ht'] : $cfg->getDefaultTopicId();
 
 if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
     $form = $topic->getForm();
@@ -47,16 +47,9 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
                 <option value="" selected="selected">&mdash; <?php echo __('Select a Help Topic');?> &mdash;</option>
                 <?php
                 if($topics=Topic::getPublicHelpTopics()) {
-                    if(isset($_GET['ht']) && $_GET['ht'] > 0 ){
-                        foreach($topics as $id =>$name) {
-                            echo sprintf('<option value="%d" %s>%s</option>',
-                                    $id, ($_GET['ht']==$id)?'selected="selected"':'', $name);
-                        }
-                    } else {
-                        foreach($topics as $id =>$name) {
-                            echo sprintf('<option value="%d" %s>%s</option>',
-                                    $id, ($info['topicId']==$id)?'selected="selected"':'', $name);
-                        }
+                    foreach($topics as $id =>$name) {
+                        echo sprintf('<option value="%d" %s>%s</option>',
+                                $id, ($info['topicId']==$id)?'selected="selected"':'', $name);
                     }
                 } else { ?>
                     <option value="0" ><?php echo __('General Inquiry');?></option>

--- a/include/client/open.inc.php
+++ b/include/client/open.inc.php
@@ -47,9 +47,16 @@ if ($info['topicId'] && ($topic=Topic::lookup($info['topicId']))) {
                 <option value="" selected="selected">&mdash; <?php echo __('Select a Help Topic');?> &mdash;</option>
                 <?php
                 if($topics=Topic::getPublicHelpTopics()) {
-                    foreach($topics as $id =>$name) {
-                        echo sprintf('<option value="%d" %s>%s</option>',
-                                $id, ($info['topicId']==$id)?'selected="selected"':'', $name);
+                    if(isset($_GET['ht']) && $_GET['ht'] > 0 ){
+                        foreach($topics as $id =>$name) {
+                            echo sprintf('<option value="%d" %s>%s</option>',
+                                    $id, ($_GET['ht']==$id)?'selected="selected"':'', $name);
+                        }
+                    } else {
+                        foreach($topics as $id =>$name) {
+                            echo sprintf('<option value="%d" %s>%s</option>',
+                                    $id, ($info['topicId']==$id)?'selected="selected"':'', $name);
+                        }
                     }
                 } else { ?>
                     <option value="0" ><?php echo __('General Inquiry');?></option>


### PR DESCRIPTION
This pull request provides the option to preselect a help topic on ticket open by specifying the topic ID in the URL request string.

Example:
http://example.com/open.php?ht=5

This will fill the topicID field on open.php with the option that has a value of 'ht' or 5 in this case.

If a topic ID isn't specified the default action is to fill the field with the "Select a Help Topic" text.