### PR TITLE
forms: Avoid dropping the CDATA table

### DIFF
--- a/include/class.dynamic_forms.php
+++ b/include/class.dynamic_forms.php
@@ -327,7 +327,7 @@ class DynamicForm extends VerySimpleModel {
                     $cdata['object_id'],
                     db_input($answer->getEntry()->get('object_id')))
             .' ON DUPLICATE KEY UPDATE '.$fields;
-        if (!db_query($sql) || !db_affected_rows())
+        if (!db_query($sql))
             return self::dropDynamicDataView($cdata['table']);
     }
 
@@ -523,7 +523,7 @@ class TicketForm extends DynamicForm {
         $sql = 'INSERT INTO `'.TABLE_PREFIX.'ticket__cdata` SET '.$fields
             .', `ticket_id`='.db_input($answer->getEntry()->get('object_id'))
             .' ON DUPLICATE KEY UPDATE '.$fields;
-        if (!db_query($sql) || !db_affected_rows())
+        if (!db_query($sql))
             return self::dropDynamicDataView();
     }
 }


### PR DESCRIPTION
MySql 5.6 and MariaDB 10 will return affected_rows == 0 if updating a row to its current values. Therefore, if an object is "edited", but none of the CDATA is modified, then the CDATA table might be dropped and rebuilt.