### PR TITLE
bounce: Avoid a loop on new message alert to staff

### DIFF
--- a/include/class.filter.php
+++ b/include/class.filter.php
@@ -905,7 +905,7 @@ class TicketFilter {
 
         $bounce_headers = array(
             'From'  => array('stripos',
-                        array('MAILER-DAEMON', '<>'), null, false),
+                        array('MAILER-DAEMON', '<>', 'postmaster@'), null, false),
             'Subject'   => array('stripos',
                 array('DELIVERY FAILURE', 'DELIVERY STATUS',
                     'UNDELIVERABLE:', 'Undelivered Mail Returned'), 0),

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1807,19 +1807,21 @@ class Ticket {
             }
         }
 
-        if(!$alerts) return $message; //Our work is done...
-
         // Do not auto-respond to bounces and other auto-replies
-        $autorespond = isset($vars['flags'])
-            ? !$vars['flags']['bounce'] && !$vars['flags']['auto-reply']
-            : true;
-        if ($autorespond && $message->isAutoReply())
-            $autorespond = false;
+        if ($alerts)
+            $alerts = isset($vars['flags'])
+                ? !$vars['flags']['bounce'] && !$vars['flags']['auto-reply']
+                : true;
+        if ($alerts && $message->isBounceOrAutoReply())
+            $alerts = false;
 
-        $this->onMessage($message, $autorespond); //must be called b4 sending alerts to staff.
+        $this->onMessage($message, $alerts); //must be called b4 sending alerts to staff.
 
-        if ($autorespond && $cfg && $cfg->notifyCollabsONNewMessage())
+        if ($alerts && $cfg && $cfg->notifyCollabsONNewMessage())
             $this->notifyCollaborators($message, array('signature' => ''));
+
+        if (!$alerts)
+            return $message; //Our work is done...
 
         $dept = $this->getDept();
 


### PR DESCRIPTION
If a new message alert bounced to a staff member and the postmaster sent back a bounce notice, which was threaded, then the agent might receive another new message alert, which would continue a bounce loop.