### PR TITLE
Fixes bare header redirect

### DIFF
--- a/scp/login.php
+++ b/scp/login.php
@@ -67,7 +67,7 @@ elseif ($_GET['do']) {
 elseif (!$thisstaff || !($thisstaff->getId() || $thisstaff->isValid())) {
     if (($user = StaffAuthenticationBackend::processSignOn($errors, false))
             && ($user instanceof StaffSession))
-       @header("Location: $dest");
+       Http::redirect($dest);
 }
 
 // Browsers shouldn't suggest saving that username/password


### PR DESCRIPTION
This fixes a bug where the browser will fail to redirect away from the login page if the client's browser doesn't allow for location mutations with the 422 response code. This was triggered since there was no exit call after the bare header mutation. Using the HTTP#redirect call solves this problem.

This issue only impacted SSO auth plugins.