### PR TITLE
Make fulltext search optional on user lookup

### DIFF
--- a/include/class.search.php
+++ b/include/class.search.php
@@ -266,7 +266,7 @@ class MysqlSearchBackend extends SearchBackend {
         if ($model instanceof Ticket)
             $attrs['title'] = $attrs['number'].' '.$attrs['title'];
         elseif ($model instanceof User)
-            $content .= implode("\n", $attrs['emails']);
+            $content .=' '.implode("\n", $attrs['emails']);
 
         $title = $attrs['title'] ?: '';
 


### PR DESCRIPTION
Fulltext search is not ideal for user lookup - too many MYSQL dependent variables like min-word-length stop words and characters types. This pull request makes the fulltext based user lookup optional and disabled by default until we address the limitations.