### PR TITLE
Fix due date check when creating and updating tickets

### DIFF
--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -2645,14 +2645,17 @@ implements RestrictedAccess, Threadable {
             $errors['err'] = __('Missing or invalid data - check the errors and try again');
 
         if ($vars['duedate']) {
+            //Set Due Date/Time and Current Time to DBTimezone
+            $tempduedate = new DateTime($cfg->getDbTimezone().$vars['duedate'].' '.$vars['time']);
+            $currentdate = new DateTime('@'.time());
+            $currentdate->setTimeZone(new DateTimeZone($cfg->getDbTimezone()));
             if ($this->isClosed())
                 $errors['duedate']=__('Due date can NOT be set on a closed ticket');
             elseif (!$vars['time'] || strpos($vars['time'],':') === false)
                 $errors['time']=__('Select a time from the list');
             elseif (strtotime($vars['duedate'].' '.$vars['time']) === false)
                 $errors['duedate']=__('Invalid due date');
-            // FIXME: Using time() violates database and user timezone
-            elseif (strtotime($vars['duedate'].' '.$vars['time']) <= time())
+            elseif ($tempduedate <= $currentdate)
                 $errors['duedate']=__('Due date must be in the future');
         }
 
@@ -3000,11 +3003,15 @@ implements RestrictedAccess, Threadable {
 
         //Make sure the due date is valid
         if($vars['duedate']) {
+            //Set Due Date/Time and Current Time to DBTimezone
+            $tempduedate = new DateTime($cfg->getDbTimezone().$vars['duedate'].' '.$vars['time']);
+            $currentdate = new DateTime('@'.time());
+            $currentdate->setTimeZone(new DateTimeZone($cfg->getDbTimezone()));
             if(!$vars['time'] || strpos($vars['time'],':')===false)
                 $errors['time']=__('Select a time from the list');
             elseif(strtotime($vars['duedate'].' '.$vars['time'])===false)
                 $errors['duedate']=__('Invalid due date');
-            elseif(strtotime($vars['duedate'].' '.$vars['time'])<=time())
+            elseif ($tempduedate <= $currentdate)
                 $errors['duedate']=__('Due date must be in the future');
         }
 


### PR DESCRIPTION
Fixes a bug created by trying to compare the due date plus time entered by the agent to the current date/time by using the **time()** function.  The **time()** function creates a timestamp in UTC while the due date plus time stays in the agent's timezone.  This meant that the **duedate <= time()** check may report **"Due date must be in the future"** even if the due date was after the current time depending on the user's timezone.

In my case I am in the EDT timezone (UTC -4:00) and that meant I could not schedule the due date plus time within 4 hours of the current time because the system would come back with the error **"Due date must be in the future"**.

This fix converts both the due date plus time and the current date/time to the user's timezone prior to comparing the two times.

I used **$cfg->getDbTimezone()** to get the agent's timezone.  **Thoughts on if there is a better function to use to pull this information?**