### PR TITLE
Display message type on message

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -386,6 +386,11 @@ $tcount+= $ticket->getNumNotes();
 <div id="ticket_thread">
     <?php
     $threadTypes=array('M'=>'message','R'=>'response', 'N'=>'note');
+    $threadTypeNames = array(
+        'M' => __('Client Message'),
+        'R' => __('Agent Reply to Client'),
+        'N' => __('Internal Note')
+    );
     /* -------- Messages & Responses & Notes (if inline)-------------*/
     $types = array('M', 'R', 'N');
     if(($thread=$ticket->getThreadEntries($types))) {
@@ -398,7 +403,12 @@ $tcount+= $ticket->getNumNotes();
                     <span style="display:inline-block"><?php
                         echo Format::db_datetime($entry['created']);?></span>
                     <span style="display:inline-block;padding:0 1em" class="faded title"><?php
-                        echo Format::truncate($entry['title'], 100); ?></span>
+                        if (!empty($entry['title']) && $entry['thread_type'] !== 'M') {
+                            echo Format::truncate($entry['title'], 100);
+                        } else {
+                            echo $threadTypeNames[$entry['thread_type']];
+                        }
+                        ?></span>
                     </span>
                     <span class="pull-right" style="white-space:no-wrap;display:inline-block">
                         <span style="vertical-align:middle;" class="textra"></span>


### PR DESCRIPTION
This was more of an internal request than useful feature for every user. But I thought I'd see what you think anyway.

Displays what kind of entry each message is on the ticket thread:
![](http://img.ctrlv.in/img/15/10/30/5633de67a87b8.png)