### PR TITLE
Fix a bug with the reactor bar appearing on top of the overlay.

### DIFF
--- a/css/redactor.css
+++ b/css/redactor.css
@@ -327,7 +327,7 @@ body .redactor_box_fullscreen {
   background: #fff;
   border: none;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-  z-index: 1;
+  z-index: 1 !important;
 }
 .redactor_toolbar:after {
   content: "";


### PR DESCRIPTION
![](http://img.ctrlv.in/img/15/10/30/5633e25557aa4.png)

When the overlay appears and you have previously scrolled down the page, the reactor bar appears on top of it. reactor.min.js sets an unnecessarily high z-index when the bar is appearing on top of the text box. The issue comes from this line in reactor.js: https://github.com/yiiext/imperavi-redactor-widget/blob/4d518f7b294785d3c1ec304abe38a513ebae5638/assets/redactor.js#L2472

Forcing a lower z-index on the reactor bar to fixes it. Using !important isn't a good practice but it's the only way since we can't modify the library. The latest version (10.2.5) doesn't appear to set the z-index so that will probably fix it. Could be worth looking into upgrading.