### PR TITLE
Collapse ticket threads and system messages.

### DIFF
--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -439,7 +439,7 @@ foreach (DynamicFormEntry::forTicket($ticket->getId()) as $form) {
         list($label, $v) = $stuff;
 ?>
         <tr>
-            <td width="200"><?php
+            <td width="200"><th><?php
 echo Format::htmlchars($label);
             ?>:</th>
             <td><?php
@@ -465,18 +465,489 @@ $tcount = $ticket->getThreadEntries($types)->count();
             echo sprintf('&nbsp;(%d)', $ticket->getNumTasks());
         ?></a></li>
 </ul>
-
 <div id="ticket_tabs_container">
-<div id="ticket_thread" class="tab_content">
-<?php
+    <div id="ticket_thread" class="tab_content">
+    
+<?php 
     // Render ticket thread
-    $ticket->getThread()->render(
+/*    $ticket->getThread()->render(
             array('M', 'R', 'N'),
             array(
                 'html-id' => 'ticketThread',
                 'mode' => Thread::MODE_STAFF)
             );
-?>
+ */?>
+
+<!-- Thread Preview HTML Start --> 
+        <div id="thread-items">
+<!-- First 2 entries visible --> 
+    
+        <div id="thread-entry-1" class="thread-row">
+            <div class="thread-entry message collapsed avatar">
+                <span class="pull-right avatar">
+                    <img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam" data-pin-nopin="true">    
+                </span>
+                <div class="header">
+                    <div class="pull-right">
+                        <span class="thread-actions muted-button pull-right" data-dropdown="#entry-action-more-1">
+                            <i class="icon-caret-down"></i>
+                        </span>
+                        <div id="entry-action-more-1" class="action-dropdown anchor-right" style="left: 711.25px; top: 28px; display: none;">
+                            <ul class="title">
+                                <li>
+                                    <a class="no-pjax" href="#" onclick="javascript:
+                                        var url = 'ajax.php/tickets/6/thread/25/edit';
+                                        $.dialog(url, [201], function(xhr, resp) {
+                                          var json = JSON.parse(resp);
+                                          if (!json || !json.thread_id)
+                                            return;
+                                          $('#thread-entry-'+json.thread_id)
+                                            .attr('id', 'thread-entry-' + json.new_id)
+                                            .html(json.entry)
+                                            .find('.thread-body')
+                                            .delay(500)
+                                            .effect('highlight');
+                                        }, {size:'large'});; return false;">
+                                        <i class="icon-pencil"></i> Edit</a>
+                                </li>
+                            </ul>
+                        </div>
+                        <span class="textra light">
+                        </span>
+                    </div>
+                    <b class="thread-header" data-dropdown="#user-dropdown">John Smith</b> <span class="thread-header muted">posted <a name="entry-2" href="#entry-2"><time class="relative" datetime="2015-10-02T21:14:00+00:00" title="Friday, October 2, 2015 at 4:14 PM">18 days ago</time></a></span>        
+                    <span style="max-width:500px" class="faded title truncate"></span>
+                    <div class="thread-button">&nbsp;</div>
+                </div>
+                <div class="thread-body no-pjax">
+                    <div class="thread-teaser">Etiam ligula ex, facilisis eget nisl id, egestas blandit mi. Sed ut lacinia erat, a facilisis ligula. Praesent mollis erat et magna ultricies, cursus vulputate lacus imperdiet. Sed ligula metus, iaculis at malesuada in, aliquet sed erat. Suspendisse ut bibendum magna. Nam vel dolor erat. Donec sagittis diam quis orci hendrerit dapibus. Praesent elementum lectus et imperdiet venenatis. Aliquam quis leo in mi maximus venenatis et nec ipsum. Integer quis tincidunt libero, id varius erat. Sed tempus odio sit amet euismod scelerisque.</div>
+                    <div class="clear"></div>
+                </div>
+            </div>
+        </div>
+            
+        <div id="thread-entry-2" class="thread-row">
+            <div class="thread-entry response collapsed avatar">
+                <span class="pull-left avatar">
+                    <img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam" data-pin-nopin="true">    
+                </span>
+                <div class="header">
+                    <div class="pull-right">
+                        <span class="thread-actions muted-button pull-right" data-dropdown="#entry-action-more-2">
+                            <i class="icon-caret-down"></i>
+                        </span>
+                        <div id="entry-action-more-2" class="action-dropdown anchor-right" style="left: 711.25px; top: 28px; display: none;">
+                            <ul class="title">
+                                <li>
+                                    <a class="no-pjax" href="#" onclick="javascript:
+                                        var url = 'ajax.php/tickets/6/thread/25/edit';
+                                        $.dialog(url, [201], function(xhr, resp) {
+                                          var json = JSON.parse(resp);
+                                          if (!json || !json.thread_id)
+                                            return;
+                                          $('#thread-entry-'+json.thread_id)
+                                            .attr('id', 'thread-entry-' + json.new_id)
+                                            .html(json.entry)
+                                            .find('.thread-body')
+                                            .delay(500)
+                                            .effect('highlight');
+                                        }, {size:'large'});; return false;">
+                                        <i class="icon-pencil"></i> Edit</a>
+                                </li>
+                            </ul>
+                        </div>
+                        <span class="textra light">
+                        </span>
+                    </div>
+                    <b class="thread-header" data-dropdown="#agent-dropdown">John Smith</b> <span class="thread-header muted">posted <a name="entry-2" href="#entry-2"><time class="relative" datetime="2015-10-02T21:14:00+00:00" title="Friday, October 2, 2015 at 4:14 PM">18 days ago</time></a></span>        
+                    <span style="max-width:500px" class="faded title truncate"></span>
+                    <div class="thread-button">&nbsp;</div>
+                </div>
+                <div class="thread-body no-pjax">
+                    <div class="thread-teaser">Etiam ligula ex, facilisis eget nisl id, egestas blandit mi. Sed ut lacinia erat, a facilisis ligula. Praesent mollis erat et magna ultricies, cursus vulputate lacus imperdiet. Sed ligula metus, iaculis at malesuada in, aliquet sed erat. Suspendisse ut bibendum magna. Nam vel dolor erat. Donec sagittis diam quis orci hendrerit dapibus. Praesent elementum lectus et imperdiet venenatis. Aliquam quis leo in mi maximus venenatis et nec ipsum. Integer quis tincidunt libero, id varius erat. Sed tempus odio sit amet euismod scelerisque.</div>
+                    <div class="clear"></div>
+                </div>
+            </div>
+        </div>
+            
+
+
+<!-- Thread Collapse Start -->
+
+            <div class="thread-messages-group thread-group">
+                <div class="top-bar"></div>
+                <div class="center-bar"><span>4 older messages</span></div>
+                <div class="bottom-bar"></div>
+            </div>
+
+<!-- Grouped entries -->
+
+        <div id="thread-entry-3" class="thread-row thread-collapse">
+            <div class="thread-entry collapsed message avatar">
+                <span class="pull-right avatar">
+                    <img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam" data-pin-nopin="true">    
+                </span>
+                <div class="header">
+                    <div class="pull-right">
+                        <span class="thread-actions muted-button pull-right" data-dropdown="#entry-action-more-3">
+                            <i class="icon-caret-down"></i>
+                        </span>
+                        <div id="entry-action-more-3" class="action-dropdown anchor-right" style="left: 711.25px; top: 28px; display: none;">
+                            <ul class="title">
+                                <li>
+                                    <a class="no-pjax" href="#" onclick="javascript:
+                                        var url = 'ajax.php/tickets/6/thread/25/edit';
+                                        $.dialog(url, [201], function(xhr, resp) {
+                                          var json = JSON.parse(resp);
+                                          if (!json || !json.thread_id)
+                                            return;
+                                          $('#thread-entry-'+json.thread_id)
+                                            .attr('id', 'thread-entry-' + json.new_id)
+                                            .html(json.entry)
+                                            .find('.thread-body')
+                                            .delay(500)
+                                            .effect('highlight');
+                                        }, {size:'large'});; return false;">
+                                        <i class="icon-pencil"></i> Edit</a>
+                                </li>
+                            </ul>
+                        </div>
+                        <span class="textra light">
+                        </span>
+                    </div>
+                    <b class="thread-header" data-dropdown="#user-dropdown">John Smith</b> <span class="thread-header muted">posted <a name="entry-2" href="#entry-2"><time class="relative" datetime="2015-10-02T21:14:00+00:00" title="Friday, October 2, 2015 at 4:14 PM">18 days ago</time></a></span>        
+                    <span style="max-width:500px" class="faded title truncate"></span>
+                    <div class="thread-button">&nbsp;</div>
+                </div>
+                <div class="thread-body no-pjax">
+                    <div class="thread-teaser">Etiam ligula ex, facilisis eget nisl id, egestas blandit mi. Sed ut lacinia erat, a facilisis ligula. Praesent mollis erat et magna ultricies, cursus vulputate lacus imperdiet. Sed ligula metus, iaculis at malesuada in, aliquet sed erat. Suspendisse ut bibendum magna. Nam vel dolor erat. Donec sagittis diam quis orci hendrerit dapibus. Praesent elementum lectus et imperdiet venenatis. Aliquam quis leo in mi maximus venenatis et nec ipsum. Integer quis tincidunt libero, id varius erat. Sed tempus odio sit amet euismod scelerisque.</div>
+                    <div class="clear"></div>
+                </div>
+            </div>
+        </div>
+            
+
+        <div id="thread-entry-4" class="thread-row thread-collapse">
+            <div class="thread-entry collapsed response avatar">
+                <span class="pull-left avatar">
+                    <img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam" data-pin-nopin="true">    
+                </span>
+                <div class="header">
+                    <div class="pull-right">
+                        <span class="thread-actions muted-button pull-right" data-dropdown="#entry-action-more-4">
+                            <i class="icon-caret-down"></i>
+                        </span>
+                        <div id="entry-action-more-4" class="action-dropdown anchor-right" style="left: 711.25px; top: 28px; display: none;">
+                            <ul class="title">
+                                <li>
+                                    <a class="no-pjax" href="#" onclick="javascript:
+                                        var url = 'ajax.php/tickets/6/thread/25/edit';
+                                        $.dialog(url, [201], function(xhr, resp) {
+                                          var json = JSON.parse(resp);
+                                          if (!json || !json.thread_id)
+                                            return;
+                                          $('#thread-entry-'+json.thread_id)
+                                            .attr('id', 'thread-entry-' + json.new_id)
+                                            .html(json.entry)
+                                            .find('.thread-body')
+                                            .delay(500)
+                                            .effect('highlight');
+                                        }, {size:'large'});; return false;">
+                                        <i class="icon-pencil"></i> Edit</a>
+                                </li>
+                            </ul>
+                        </div>
+                        <span class="textra light">
+                        </span>
+                    </div>
+                    <b class="thread-header" data-dropdown="#agent-dropdown">John Smith</b> <span class="thread-header muted">posted <a name="entry-2" href="#entry-2"><time class="relative" datetime="2015-10-02T21:14:00+00:00" title="Friday, October 2, 2015 at 4:14 PM">18 days ago</time></a></span>        
+                    <span style="max-width:500px" class="faded title truncate"></span>
+                    <div class="thread-button">&nbsp;</div>
+                </div>
+                <div class="thread-body no-pjax">
+                    <div class="thread-teaser">Etiam ligula ex, facilisis eget nisl id, egestas blandit mi. Sed ut lacinia erat, a facilisis ligula. Praesent mollis erat et magna ultricies, cursus vulputate lacus imperdiet. Sed ligula metus, iaculis at malesuada in, aliquet sed erat. Suspendisse ut bibendum magna. Nam vel dolor erat. Donec sagittis diam quis orci hendrerit dapibus. Praesent elementum lectus et imperdiet venenatis. Aliquam quis leo in mi maximus venenatis et nec ipsum. Integer quis tincidunt libero, id varius erat. Sed tempus odio sit amet euismod scelerisque.</div>
+                    <div class="clear"></div>
+                </div>
+            </div>
+        </div>
+            
+
+            <div class="thread-event action thread-collapse">
+                <span class="type-icon">
+                      <i class="faded icon-thumbs-up-alt"></i>
+                </span>
+                <span class="faded description">
+                        Closed by <b><img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam">Febuary, Nathan</b> with status of Closed <time class="relative" datetime="2015-07-27T14:43:30+00:00" title="Monday, July 27, 2015 at 9:43 AM">3 months ago</time>
+                </span>
+            </div>
+
+
+
+<!-- Grouped System events concept-->
+
+        <div id="thread-entry-5" class="thread-row thread-collapse">
+            <div class="thread-entry collapsed message avatar">
+                <span class="pull-right avatar">
+                    <img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam" data-pin-nopin="true">    
+                </span>
+                <div class="header">
+                    <div class="pull-right">
+                        <span class="thread-actions muted-button pull-right" data-dropdown="#entry-action-more-5">
+                            <i class="icon-caret-down"></i>
+                        </span>
+                        <div id="entry-action-more-5" class="action-dropdown anchor-right" style="left: 711.25px; top: 28px; display: none;">
+                            <ul class="title">
+                                <li>
+                                    <a class="no-pjax" href="#" onclick="javascript:
+                                        var url = 'ajax.php/tickets/6/thread/25/edit';
+                                        $.dialog(url, [201], function(xhr, resp) {
+                                          var json = JSON.parse(resp);
+                                          if (!json || !json.thread_id)
+                                            return;
+                                          $('#thread-entry-'+json.thread_id)
+                                            .attr('id', 'thread-entry-' + json.new_id)
+                                            .html(json.entry)
+                                            .find('.thread-body')
+                                            .delay(500)
+                                            .effect('highlight');
+                                        }, {size:'large'});; return false;">
+                                        <i class="icon-pencil"></i> Edit</a>
+                                </li>
+                            </ul>
+                        </div>
+                        <span class="textra light">
+                        </span>
+                    </div>
+                    <b class="thread-header" data-dropdown="#user-dropdown">John Smith</b> <span class="thread-header muted">posted <a name="entry-2" href="#entry-2"><time class="relative" datetime="2015-10-02T21:14:00+00:00" title="Friday, October 2, 2015 at 4:14 PM">18 days ago</time></a></span>        
+                    <span style="max-width:500px" class="faded title truncate"></span>
+                    <div class="thread-button">&nbsp;</div>
+                </div>
+                <div class="thread-body no-pjax">
+                    <div class="thread-teaser">Etiam ligula ex, facilisis eget nisl id, egestas blandit mi. Sed ut lacinia erat, a facilisis ligula. Praesent mollis erat et magna ultricies, cursus vulputate lacus imperdiet. Sed ligula metus, iaculis at malesuada in, aliquet sed erat. Suspendisse ut bibendum magna. Nam vel dolor erat. Donec sagittis diam quis orci hendrerit dapibus. Praesent elementum lectus et imperdiet venenatis. Aliquam quis leo in mi maximus venenatis et nec ipsum. Integer quis tincidunt libero, id varius erat. Sed tempus odio sit amet euismod scelerisque.</div>
+                    <div class="clear"></div>
+                </div>
+            </div>
+        </div>
+            
+
+<!-- End Grouped System events-->
+<!-- Start nested Collapsed System events System messages collapse when more than 3 in a row-->
+
+           <div class="sys-messages-group thread-collapse" >
+               <div class="thread-event">
+                <span class="type-icon">
+                    <i class="faded icon-list"></i>
+                </span>
+                <span class="description">
+                    <div class="thread-group">
+                        <div class="top-bar"></div>
+                        <div class="center-bar"><span>6 system messages</span></div>
+                        <div class="bottom-bar"></div>
+                    </div>
+                </span>
+            </div>
+<!-- Collapsed nested system messages -->
+            
+            <div class="thread-event action sys-collapse">
+                <span class="type-icon">
+                      <i class="faded icon-thumbs-up-alt"></i>
+                </span>
+                <span class="faded description">
+                        Closed by <b><img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam">Febuary, Nathan</b> with status of Closed <time class="relative" datetime="2015-07-27T14:43:30+00:00" title="Monday, July 27, 2015 at 9:43 AM">3 months ago</time>
+                </span>
+            </div>
+
+            <div class="thread-event action sys-collapse">
+                <span class="type-icon">
+                      <i class="faded icon-thumbs-up-alt"></i>
+                </span>
+                <span class="faded description">
+                        Closed by <b><img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam">Febuary, Nathan</b> with status of Closed <time class="relative" datetime="2015-07-27T14:43:30+00:00" title="Monday, July 27, 2015 at 9:43 AM">3 months ago</time>
+                </span>
+            </div>
+
+            <div class="thread-event action sys-collapse">
+                <span class="type-icon">
+                      <i class="faded icon-thumbs-up-alt"></i>
+                </span>
+                <span class="faded description">
+                        Closed by <b><img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam">Febuary, Nathan</b> with status of Closed <time class="relative" datetime="2015-07-27T14:43:30+00:00" title="Monday, July 27, 2015 at 9:43 AM">3 months ago</time>
+                </span>
+            </div>
+
+            <div class="thread-event action sys-collapse">
+                <span class="type-icon">
+                      <i class="faded icon-thumbs-up-alt"></i>
+                </span>
+                <span class="faded description">
+                        Closed by <b><img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam">Febuary, Nathan</b> with status of Closed <time class="relative" datetime="2015-07-27T14:43:30+00:00" title="Monday, July 27, 2015 at 9:43 AM">3 months ago</time>
+                </span>
+            </div>
+
+            <div class="thread-event action sys-collapse">
+                <span class="type-icon">
+                      <i class="faded icon-thumbs-up-alt"></i>
+                </span>
+                <span class="faded description">
+                        Closed by <b><img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam">Febuary, Nathan</b> with status of Closed <time class="relative" datetime="2015-07-27T14:43:30+00:00" title="Monday, July 27, 2015 at 9:43 AM">3 months ago</time>
+                </span>
+            </div>
+
+            <div class="thread-event action sys-collapse">
+                <span class="type-icon">
+                      <i class="faded icon-thumbs-up-alt"></i>
+                </span>
+                <span class="faded description">
+                        Closed by <b><img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam">Febuary, Nathan</b> with status of Closed <time class="relative" datetime="2015-07-27T14:43:30+00:00" title="Monday, July 27, 2015 at 9:43 AM">3 months ago</time>
+                </span>
+            </div>
+
+        </div>
+
+<!-- End nested collapsed System events-->
+
+        <div id="thread-entry-6" class="thread-row thread-collapse">
+            <div class="thread-entry collapsed note avatar">
+                <span class="pull-left avatar">
+                    <img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam" data-pin-nopin="true">    
+                </span>
+                <div class="header">
+                    <div class="pull-right">
+                        <span class="thread-actions muted-button pull-right" data-dropdown="#entry-action-more-6">
+                            <i class="icon-caret-down"></i>
+                        </span>
+                        <div id="entry-action-more-6" class="action-dropdown anchor-right" style="left: 711.25px; top: 28px; display: none;">
+                            <ul class="title">
+                                <li>
+                                    <a class="no-pjax" href="#" onclick="javascript:
+                                        var url = 'ajax.php/tickets/6/thread/25/edit';
+                                        $.dialog(url, [201], function(xhr, resp) {
+                                          var json = JSON.parse(resp);
+                                          if (!json || !json.thread_id)
+                                            return;
+                                          $('#thread-entry-'+json.thread_id)
+                                            .attr('id', 'thread-entry-' + json.new_id)
+                                            .html(json.entry)
+                                            .find('.thread-body')
+                                            .delay(500)
+                                            .effect('highlight');
+                                        }, {size:'large'});; return false;">
+                                        <i class="icon-pencil"></i> Edit</a>
+                                </li>
+                            </ul>
+                        </div>
+                        <span class="textra light">
+                        </span>
+                    </div>
+                    <b class="thread-header" data-dropdown="#agent-dropdown">John Smith</b> <span class="thread-header muted">posted <a name="entry-2" href="#entry-2"><time class="relative" datetime="2015-10-02T21:14:00+00:00" title="Friday, October 2, 2015 at 4:14 PM">18 days ago</time></a></span>        
+                    <span style="max-width:500px" class="faded title truncate"></span>
+                    <div class="thread-button">&nbsp;</div>
+                </div>
+                <div class="thread-body no-pjax">
+                    <div class="thread-teaser">Etiam ligula ex, facilisis eget nisl id, egestas blandit mi. Sed ut lacinia erat, a facilisis ligula. Praesent mollis erat et magna ultricies, cursus vulputate lacus imperdiet. Sed ligula metus, iaculis at malesuada in, aliquet sed erat. Suspendisse ut bibendum magna. Nam vel dolor erat. Donec sagittis diam quis orci hendrerit dapibus. Praesent elementum lectus et imperdiet venenatis. Aliquam quis leo in mi maximus venenatis et nec ipsum. Integer quis tincidunt libero, id varius erat. Sed tempus odio sit amet euismod scelerisque.</div>
+                    <div class="clear"></div>
+                </div>
+            </div>
+        </div>
+            
+        <div id="thread-entry-6" class="thread-row thread-collapse">
+            <div class="thread-entry collapsed response avatar">
+                <span class="pull-left avatar">
+                    <img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam" data-pin-nopin="true">    
+                </span>
+                <div class="header">
+                    <div class="pull-right">
+                        <span class="thread-actions muted-button pull-right" data-dropdown="#entry-action-more-6">
+                            <i class="icon-caret-down"></i>
+                        </span>
+                        <div id="entry-action-more-6" class="action-dropdown anchor-right" style="left: 711.25px; top: 28px; display: none;">
+                            <ul class="title">
+                                <li>
+                                    <a class="no-pjax" href="#" onclick="javascript:
+                                        var url = 'ajax.php/tickets/6/thread/25/edit';
+                                        $.dialog(url, [201], function(xhr, resp) {
+                                          var json = JSON.parse(resp);
+                                          if (!json || !json.thread_id)
+                                            return;
+                                          $('#thread-entry-'+json.thread_id)
+                                            .attr('id', 'thread-entry-' + json.new_id)
+                                            .html(json.entry)
+                                            .find('.thread-body')
+                                            .delay(500)
+                                            .effect('highlight');
+                                        }, {size:'large'});; return false;">
+                                        <i class="icon-pencil"></i> Edit</a>
+                                </li>
+                            </ul>
+                        </div>
+                        <span class="textra light">
+                        </span>
+                    </div>
+                    <b class="thread-header" data-dropdown="#agent-dropdown">John Smith</b> <span class="thread-header muted">posted <a name="entry-2" href="#entry-2"><time class="relative" datetime="2015-10-02T21:14:00+00:00" title="Friday, October 2, 2015 at 4:14 PM">18 days ago</time></a></span>        
+                    <span style="max-width:500px" class="faded title truncate"></span>
+                    <div class="thread-button">&nbsp;</div>
+                </div>
+                <div class="thread-body no-pjax">
+                    <div class="thread-teaser">Etiam ligula ex, facilisis eget nisl id, egestas blandit mi. Sed ut lacinia erat, a facilisis ligula. Praesent mollis erat et magna ultricies, cursus vulputate lacus imperdiet. Sed ligula metus, iaculis at malesuada in, aliquet sed erat. Suspendisse ut bibendum magna. Nam vel dolor erat. Donec sagittis diam quis orci hendrerit dapibus. Praesent elementum lectus et imperdiet venenatis. Aliquam quis leo in mi maximus venenatis et nec ipsum. Integer quis tincidunt libero, id varius erat. Sed tempus odio sit amet euismod scelerisque.</div>
+                    <div class="clear"></div>
+                </div>
+            </div>
+        </div>
+
+<!-- Start Last response visible -->
+
+         <div id="thread-entry-7" class="thread-row">
+            <div class="thread-entry message avatar">
+                <span class="pull-right avatar">
+                    <img class="avatar" alt="Avatar" src="/avatar.php?uid=0cdfde878c85cace32cd1412ae1189ad&amp;mode=ateam" data-pin-nopin="true">    
+                </span>
+                <div class="header">
+                    <div class="pull-right">
+                        <span class="thread-actions muted-button pull-right" data-dropdown="#entry-action-more-7">
+                            <i class="icon-caret-down"></i>
+                        </span>
+                        <div id="entry-action-more-7" class="action-dropdown anchor-right" style="left: 711.25px; top: 28px; display: none;">
+                            <ul class="title">
+                                <li>
+                                    <a class="no-pjax" href="#" onclick="javascript:
+                                        var url = 'ajax.php/tickets/6/thread/25/edit';
+                                        $.dialog(url, [201], function(xhr, resp) {
+                                          var json = JSON.parse(resp);
+                                          if (!json || !json.thread_id)
+                                            return;
+                                          $('#thread-entry-'+json.thread_id)
+                                            .attr('id', 'thread-entry-' + json.new_id)
+                                            .html(json.entry)
+                                            .find('.thread-body')
+                                            .delay(500)
+                                            .effect('highlight');
+                                        }, {size:'large'});; return false;">
+                                        <i class="icon-pencil"></i> Edit</a>
+                                </li>
+                            </ul>
+                        </div>
+                        <span class="textra light">
+                        </span>
+                    </div>
+                    <b class="thread-header" data-dropdown="#user-dropdown">John Smith</b> <span class="thread-header muted">posted <a name="entry-2" href="#entry-2"><time class="relative" datetime="2015-10-02T21:14:00+00:00" title="Friday, October 2, 2015 at 4:14 PM">18 days ago</time></a></span>        
+                    <span style="max-width:500px" class="faded title truncate"></span>
+                    <div class="thread-button">&nbsp;</div>
+                </div>
+                <div class="thread-body no-pjax">
+                    <div class="thread-teaser">Etiam ligula ex, facilisis eget nisl id, egestas blandit mi. Sed ut lacinia erat, a facilisis ligula. Praesent mollis erat et magna ultricies, cursus vulputate lacus imperdiet. Sed ligula metus, iaculis at malesuada in, aliquet sed erat. Suspendisse ut bibendum magna. Nam vel dolor erat. Donec sagittis diam quis orci hendrerit dapibus. Praesent elementum lectus et imperdiet venenatis. Aliquam quis leo in mi maximus venenatis et nec ipsum. Integer quis tincidunt libero, id varius erat. Sed tempus odio sit amet euismod scelerisque.</div>
+                    <div class="clear"></div>
+                </div>
+            </div>
+        </div>
+            
+<!-- End last response -->
+
+        </div>
+    </div>
+</div>
+<!-- End Thread Preview HTML -->
+    
+    
 <div class="clear"></div>
 <?php if($errors['err']) { ?>
     <div id="msg_error"><?php echo $errors['err']; ?></div>
@@ -485,6 +956,7 @@ $tcount = $ticket->getThreadEntries($types)->count();
 <?php }elseif($warn) { ?>
     <div id="msg_warning"><?php echo $warn; ?></div>
 <?php } ?>
+
 
 <div class="sticky bar stop actions" id="response_options"
 >
@@ -776,8 +1248,7 @@ $tcount = $ticket->getThreadEntries($types)->count();
        </p>
    </form>
  </div>
- </div>
-</div>
+
 <div style="display:none;" class="dialog" id="print-options">
     <h3><?php echo __('Ticket Print Options');?></h3>
     <a class="close" href=""><i class="icon-remove-circle"></i></a>
@@ -875,6 +1346,76 @@ $tcount = $ticket->getThreadEntries($types)->count();
     </form>
     <div class="clear"></div>
 </div>
+
+
+<div id="user-dropdown" class="ticket-profile action-dropdown anchor-left">
+    <ul class="bleed-left">
+        <li class="profile-info">
+            <div class="avatar pull-left">
+                <img class="avatar" alt="Avatar" src="/avatar.php?uid=0ea9072b3cc514337faa291cf8e466c3&amp;mode=ateam" data-pin-nopin="true">
+            </div>
+            <div class="profile-group pull-left">
+                <h3>John Smith</h3>
+                <p>Acme Brick Company</p>
+                <a class="action-button">View Profile</a>
+            </div>
+            <div class="clear"></div>
+        </li>
+        <li class="profile-team clear">
+            <p>Email:<a>nathan@acmebrick.com</a></p>
+        </li>
+        <li class="profile-info">
+                <div class="info-item">
+                    <span>Status:</span>Locked (Pending Activiation)
+                </div>
+                <div class="info-item">
+                    <span>Created:</span>7/28/15, 2:59pm
+                </div>
+                <div class="info-item">
+                    <span>Updated:</span>8/7/15, 2:44pm
+                </div>
+        </li>
+        <li class="profile-footer">
+                <p>Last message: <span>Oct 23, 2015</span></p>
+        </li>
+    </ul>
+</div> 
+
+
+<div id="agent-dropdown" class="ticket-profile action-dropdown anchor-left">
+    <ul class="bleed-left">
+        <li class="profile-info">
+            <div class="avatar pull-left">
+                <img class="avatar" alt="Avatar" src="/avatar.php?uid=0ea9072b3cc514337faa291cf8e466c3&amp;mode=ateam" data-pin-nopin="true">
+            </div>
+            <div class="profile-group pull-left">
+                <h3>Nathan Febuary</h3>
+                <p>Marketing</p>
+                <a class="action-button">View Profile</a>
+            </div>
+            <div class="clear"></div>
+        </li>
+        <li class="profile-team clear">
+            <p>Team(s):<a>Team Awesome</a></p>
+        </li>
+        <li class="profile-info">
+                <div class="info-item">
+                    <span>942</span>Tickets Assigned
+                </div>
+                <div class="info-item">
+                    <span>20</span>Tickets Answered
+                </div>
+                <div class="info-item">
+                    <span>6</span>Tasks Completed
+                </div>
+        </li>
+        <li class="profile-footer">
+                <p>Last response: <span>Oct 23, 2015</span></p>
+        </li>
+    </ul>
+</div> 
+
+
 <script type="text/javascript">
 $(function() {
     $(document).on('click', 'a.change-user', function(e) {
@@ -897,4 +1438,27 @@ $(function() {
         });
     });
 });
+    
+    
+
+    
+    $('.thread-button').on('click', function(){
+        if ($(this).closest('.thread-entry').hasClass('collapsed')) {
+            $(this).closest('.thread-entry').removeClass('collapsed');
+        } else if(!$(this).closest('.thread-entry').hasClass('collapsed')) {
+            $(this).closest('.thread-entry').addClass('collapsed');
+        }
+    });
+                         
+    $('.thread-messages-group').on('click',function(){
+        $(this).addClass('hidden-thread');
+        $('.thread-row, .sys-messages-group').removeClass('thread-collapse');
+        $('.thread-event').removeClass('thread-collapse');
+    }) 
+    $('.thread-event').on('click',function(){
+        $(this).addClass('hidden-thread');
+        $(this).closest('.sys-messages-group').find('.thread-event').removeClass('sys-collapse');
+    })
+
+    
 </script>

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -12,8 +12,9 @@ body, html {
     margin:0;
     padding:0;
 }
-
 .link,
+.button.link,
+¡.link,
 a {
     color:#184E81;
     text-decoration:none;
@@ -906,7 +907,8 @@ h2 .reload {
     margin:0;
 }
 .thread-entry {
-    margin-bottom: 15px;
+    margin-bottom: 5px;
+    margin-top: 5px;
     z-index: 0;
 }
 .thread-entry::after {
@@ -997,13 +999,15 @@ img.avatar {
     border-right: 8px solid #CCC;
 }
 .thread-entry.note:not(.avatar) .header {
-    background-color: #f4f4f4;
+    background-color: #fefdc6;
 }
 .thread-entry.avatar.response .header:before {
-    border-right-color: #ccb3af;
+    border-right-color: #ccb38f;
 }
 .thread-entry.avatar.note .header:before {
-    border-right-color: #ccccb0;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  border-right: 8px solid #ccccb0;
 }
 .thread-entry.avatar.response .header:after,
 .thread-entry.avatar.note .header:after {
@@ -1014,12 +1018,11 @@ img.avatar {
     border-right: 7px solid #FFE0B3;
     margin-left: 1px;
 }
-
 .thread-entry.note .header {
-    background:#FFE;
+    background:#fefdc6;
 }
 .thread-entry.avatar.note .header:after {
-    border-right-color: #FFE;
+    border-right-color: #fefdc6;
 }
 .thread-entry .header .title {
     max-width: 500px;
@@ -2151,6 +2154,10 @@ div.selected-signature .inner {
     top: 4px;
     right: 5px;
 }
+.muted, .muted a time.relative {
+  color: #666!IMPORTANT;
+  color: rgba(0,0,0,0.5)!IMPORTANT;
+}
 .muted-button:hover {
     border: 1px solid #aaa;
     border: 1px solid rgba(0,0,0,0.3);
@@ -2690,17 +2697,365 @@ td.indented {
     vertical-align: middle;
 }
 
-#thread-items::before {
+
+
+
+
+
+/******** Start Ticket Group Styles ********/
+/***Grouped system entries***/
+
+.sys-messages-group .thread-event .thread-group {
+    position:relative;
+    top:0px;
+}
+.sys-messages-group .thread-event:first-child .description {
+    line-height:0;
+    padding-left:0;
+    margin-left:0;
+    padding-top:0;
+}
+.sys-messages-group .thread-event:first-child > span.type-icon {
+    top:5px;
+}
+
+.thread-event.sys-collapse, .thread-event.thread-collapse, .sys-messages-group.thread-collapse, .thread-row.thread-collapse,
+.thread-messages-group.hidden-thread, .thread-event.hidden-thread {
+    display:none;
+}
+
+/*** Thread Group ***/
+.thread-messages-group {
+    margin-bottom:5px;
+}
+.thread-group {
+    background-color:#f7f7f7;
+    cursor:pointer;
+}
+.thread-group:before  {
+    display:block;
+    content:'';
+    border-top: 2px solid white;
+}
+.thread-group:after {
+    display:block;
+    content:'';
+    border-bottom: 2px solid white;
+}
+
+.thread-group .top-bar {
+    border-top:1px dotted #ccc;
+    height:10px;
+}
+
+.thread-group .center-bar {
+    border-top:1px dotted #ccc;
+    border-bottom:1px dotted #ccc;
+    height:10px;
+    text-align:center;
+}
+.thread-group .center-bar span {
+    background-color:#f7f7f7;
+    padding:2px 10px;
+    color:#666;
+    position:relative;
+    top:-3px;
+}
+.sys-messages-group .thread-event .thread-group .center-bar span {
+    background-color:#f7f7f7;
+    padding:2px 10px;
+    color:#666;
+    position:relative;
+    top:5px;
+    left:-18px;
+}
+.thread-group .bottom-bar {
+    border-bottom:1px dotted #ccc;
+    height:10px;
+}
+
+/******** End Thread Group Styles ********/
+
+/******** Start Thread Ticket collapse Styles ********/
+
+/*
+This will set the collapse/expand button below the name and the actions buttons. 
+*/
+.thread-header {
+    position:relative;
+    z-index:4;
+    color:#555;
+    
+}
+.thread-entry .thread-button {
+    height:30px;
+    width:930px;
+    position:absolute;
+    margin-top:-25px;
+    margin-left:-10px;
+    display:block;
+    cursor:pointer;
+    z-index:3;
+}
+
+.thread-entry .thread-actions {
+    position:relative;
+    z-index:4;
+    opacity:.5;
+    -webkit-transition: opacity .5s;
+    transition: opacity .5s;
+    padding:3px 8px;
+    margin-top:-3px;
+}
+
+.thread-entry .header:hover .thread-actions {
+    opacity:1;
+}
+
+/***Collapsed CSS***/
+
+.thread-entry.collapsed .thread-button {
+    height:60px;
+}
+.thread-entry.collapsed > span.avatar {
+    display:none;
+}
+.thread-entry.avatar.collapsed .header:before, .thread-entry.collapsed.avatar .header:after {
+    display:none;
+}
+
+
+.thread-row:first-child .thread-entry.collapsed {
+    margin:0 0 0px 0!IMPORTANT;
+}
+
+.thread-entry.message.collapsed {
+    border-left:4px solid #7a91b8;
+    border-radius:0;
+}
+
+.thread-entry.response.collapsed {
+    border-left:4px solid #e4a346;
+    border-radius:0;
+}
+.thread-entry.note.collapsed {
+    border-left:4px solid #e2c24c;
+    border-radius:0;
+}
+.thread-entry.collapsed {
+    background-color:#f7f7f7;
+    margin:0px 0!IMPORTANT;
+    cursor:pointer;
+}
+.thread-entry.collapsed.message .header > b {
+    color:#7a91b8!IMPORTANT;
+}
+
+.thread-entry.collapsed.response .header > b {
+    color:#e4a346!IMPORTANT;
+    }
+
+.thread-entry.collapsed.note .header > b {
+    color:#e2c24c!IMPORTANT;
+    }
+
+.thread-entry.collapsed .header {
+    background-color:#f7f7f7;
+    border-bottom:1px solid #f7f7f7;
+    border-left:0;
+    border-radius:0;
+}
+
+.thread-entry.collapsed .thread-body {
+    background-color:#f7f7f7;
+    padding-top:0;
+    border-left:0;
+    border-right:1px solid #ccc;
+    height:20px;
+    overflow:hidden;
+    padding-bottom:10px;
+    border-radius:0;
+}
+.thread-entry.collapsed .thread-body .thread-teaser {
+    width: auto;
+    display: inline-block;
+    max-width: 98%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    vertical-align: bottom;
+}
+
+
+/***Overrides***/
+.thread-row:first-child .thread-entry {
+    margin-bottom:5px!IMPORTANT;
+}
+
+.thread-entry::before, .thread-entry::after {
+    display:none;
+}
+
+.thread-entry .header {
+    border-radius:0;
+    cursor:pointer;
+}
+
+.thread-entry .thread-body {
+    border: 1px solid #ddd;
+    border-top: none;
+    border-bottom: 1px solid #ccc;
+    border-radius: 0;
+    padding-bottom:10px;
+    height:auto;
+    overflow:visible;
+}
+.thread-entry .thread-body .thread-teaser {
+    width: auto;
+    display: block;
+    max-width: 100%;
+    white-space:normal;
+    overflow: visible;
+    text-overflow:inherit;
+    vertical-align:bottom;
+}
+/******** End Thread Preview Styles ********/
+
+/******** Start User/Agent Profile Popout *********/
+.ticket-profile.action-dropdown {
+    z-index:5!IMPORTANT;
+}
+.ticket-profile.action-dropdown > ul {
+    padding:10px 0 0 0;
+}
+.ticket-profile.action-dropdown > ul > li {
+    padding:0 10px;
+    margin-bottom:10px;
+}
+.ticket-profile.action-dropdown > ul > li:last-child {
+    margin-bottom:0px;
+}
+
+.ticket-profile.action-dropdown li.profile-info .avatar {
+    width:70px;
+}
+    /***/
+
+    .profile-group {
+        padding:0 10px;
+    }
+    .profile-group h3 {
+        padding:0;
+        margin:0;
+    }
+    .profile-group p {
+        padding:0;
+        margin:0;
+        color:#666;
+    }
+    .profile-group a.action-button {
+        margin:5px 0 0 0 !IMPORTANT;
+        width:100%;
+        padding:2px 0!IMPORTANT;
+        text-align:center;
+    }
+
+    /***/
+
+    .profile-team {
+        border-top:1px dotted #999;
+        border-bottom:1px dotted #999;
+        display:block;
+    }
+
+    .profile-team p {
+        margin:0;
+        padding:5px 0;
+    }
+
+    .profile-team a {
+        color:#666;
+        text-decoration:underline;
+        margin:0 4px;
+    }
+
+    .profile-team a:hover {
+        color:#E65524;
+    }
+
+    /***/
+
+    .profile-info .info-item {
+        padding:5px 0;
+        color:#666;
+    }
+
+    #agent-dropdown .profile-info .info-item span {
+        min-width:30px;
+        display:inline-block;
+        color:#666;
+        text-align:right;
+        margin:0 5px;
+        color:#E65524;
+        font-weight:bold;
+    }
+    #user-dropdown .profile-info .info-item span {
+        min-width:30px;
+        display:inline-block;
+        color:#666;
+        text-align:right;
+        margin:0 5px;
+        font-weight:bold;
+    }
+
+    /***/
+
+.profile-footer {
+    border-top:1px dotted #999;
+    background-color:#f4f4f4;
+    border-bottom-left-radius:6px;
+    border-bottom-right-radius:6px;
+    text-align:center;
+}
+
+.profile-footer > p {
+    margin:0;
+    padding:15px;
+}
+
+.profile-footer p > span {
+    color:#E65524;
+    font-weight:bold;
+    margin: 0 2px;
+}
+.profile-footer > a {
+    text-decoration: none;
+    padding:10px!IMPORTANT;
+    display:block;
+    border-bottom-left-radius:6px;
+    border-bottom-right-radius:6px;
+}
+
+/******** End User/Agent Profile Popout *********/
+
+
+
+
+
+
+
+
+#thread-items::after {
   border-left: 2px dotted #ddd;
   border-bottom-color: rgba(0,0,0,0.1);
   position: absolute;
   margin-left: 74px;
   z-index: -1;
   content: "";
-  top: 0;
-  bottom: 0;
-  right: 0;
-  left: 0;
+    top:0;
+    bottom:0;
+    left:0;
+    right:0;
 }
 #thread-items {
   z-index: 0;
@@ -2710,9 +3065,12 @@ td.indented {
   margin-top: 5px;
 }
 .thread-event {
-    padding: 0 2px 15px;
+    margin-top:10px;
+    margin-bottom:10px;
+    padding:0;
     margin-left: 60px;
 }
+
 .thread-event a {
     color: inherit;
 }


### PR DESCRIPTION
Adds collapsable threads, entries and system messages to the ticket
view.

Features:
Collapses all entries and system messages between the first two
messages and the very last message.
![screen shot 2015-11-02 at 3 07 36 pm](https://cloud.githubusercontent.com/assets/8247872/10894652/9f2fc308-8175-11e5-8e56-cb6e6dcd46e9.png)

System messages are collapsed if there is more than one. Colors on the collapsed thread entries determine type of entry message, response, internal note.
![screen shot 2015-11-02 at 3 07 56 pm](https://cloud.githubusercontent.com/assets/8247872/10894657/ad0f9840-8175-11e5-9019-0d21656d00cc.png)

Expanded System Message list
![screen shot 2015-11-02 at 3 08 13 pm](https://cloud.githubusercontent.com/assets/8247872/10894670/b7dd9d4e-8175-11e5-8635-275e630b7403.png)

Shows some entries expanded and some collapsed:
![screen shot 2015-11-02 at 3 08 31 pm](https://cloud.githubusercontent.com/assets/8247872/10894709/e52173b6-8175-11e5-8734-4fd460761099.png)

TO-DO:
Php needs to be added to make it fully functional.
Javascript needs to be tightened up
Small IE bug (no surprise) with the arrow pointers at the Avatars