### PR TITLE
Agent's preferences

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -1136,6 +1136,7 @@ class OsticketConfig extends Config {
             'allow_pw_reset'=>isset($vars['allow_pw_reset'])?1:0,
             'pw_reset_window'=>$vars['pw_reset_window'],
             'agent_name_format'=>$vars['agent_name_format'],
+            'hide_staff_name'=>isset($vars['hide_staff_name']) ? 1 : 0,
             'agent_avatar'=>$vars['agent_avatar'],
         ));
     }
@@ -1207,7 +1208,6 @@ class OsticketConfig extends Config {
             'show_assigned_tickets'=>isset($vars['show_assigned_tickets'])?0:1,
             'show_answered_tickets'=>isset($vars['show_answered_tickets'])?0:1,
             'show_related_tickets'=>isset($vars['show_related_tickets'])?1:0,
-            'hide_staff_name'=>isset($vars['hide_staff_name'])?1:0,
             'allow_client_updates'=>isset($vars['allow_client_updates'])?1:0,
             'ticket_lock' => $vars['ticket_lock'],
         ));

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -29,12 +29,15 @@ class Config {
     # new settings and the corresponding default values.
     var $defaults = array();                # List of default values
 
-    function Config($section=null) {
+    function Config($section=null, $defaults=array()) {
         if ($section)
             $this->section = $section;
 
         if ($this->section === null)
             return false;
+
+        if ($defaults)
+            $this->defaults = $defaults;
 
         if (isset($_SESSION['cfg:'.$this->section]))
             $this->session = &$_SESSION['cfg:'.$this->section];

--- a/include/class.mailer.php
+++ b/include/class.mailer.php
@@ -66,10 +66,14 @@ class Mailer {
         $this->ht['from'] = $from;
     }
 
-    function getFromAddress() {
+    function getFromAddress($options=array()) {
 
-        if(!$this->ht['from'] && ($email=$this->getEmail()))
-            $this->ht['from'] =sprintf('"%s" <%s>', ($email->getName()?$email->getName():$email->getEmail()), $email->getEmail());
+        if (!$this->ht['from'] && ($email=$this->getEmail())) {
+            if (($name = $options['from_name'] ?: $email->getName()))
+                $this->ht['from'] =sprintf('"%s" <%s>', $name, $email->getEmail());
+            else
+                $this->ht['from'] =sprintf('<%s>', $email->getEmail());
+        }
 
         return $this->ht['from'];
     }
@@ -318,7 +322,7 @@ class Mailer {
         $subject = preg_replace("/(\r\n|\r|\n)/s",'', trim($subject));
 
         $headers = array (
-            'From' => $this->getFromAddress(),
+            'From' => $this->getFromAddress($options),
             'To' => $to,
             'Subject' => $subject,
             'Date'=> date('D, d M Y H:i:s O'),

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -86,7 +86,8 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
                     // Defaults
                     array(
                         'default_from_name' => '',
-                        'datetime_format' => '',
+                        'datetime_format'   => '',
+                        'thread_view_order' => '',
                         ));
             $this->_config = $_config->getInfo();
         }
@@ -675,6 +676,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
         $_config->updateAll(array(
                     'datetime_format' => $vars['datetime_format'],
                     'default_from_name' => $vars['default_from_name'],
+                    'thread_view_order' => $vars['thread_view_order'],
                     )
                 );
         $this->_config = $_config->getInfo();

--- a/include/class.staff.php
+++ b/include/class.staff.php
@@ -282,6 +282,10 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
         return $this->default_signature_type;
     }
 
+    function getReplyFromNameType() {
+        return $this->default_from_name;
+    }
+
     function getDefaultPaperSize() {
         return $this->default_paper_size;
     }
@@ -621,6 +625,7 @@ implements AuthenticatedUser, EmailContact, TemplateVariable {
         $this->max_page_size = $vars['max_page_size'];
         $this->auto_refresh_rate = $vars['auto_refresh_rate'];
         $this->default_signature_type = $vars['default_signature_type'];
+        $this->default_from_name = $vars['default_from_name'];
         $this->default_paper_size = $vars['default_paper_size'];
         $this->lang = $vars['lang'];
         $this->onvacation = isset($vars['onvacation'])?1:0;

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -244,6 +244,9 @@ class Thread extends VerySimpleModel {
         if ($type && is_array($type))
             $entries->filter(array('type__in' => $type));
 
+        if ($options['sort'] && !strcasecmp($options['sort'], 'DESC'))
+            $entries->order_by('-id');
+
         // Precache all the attachments on this thread
         AttachmentFile::objects()->filter(array(
             'attachments__thread_entry__thread__id' => $this->id

--- a/include/client/templates/thread-entry.tmpl.php
+++ b/include/client/templates/thread-entry.tmpl.php
@@ -25,10 +25,10 @@ if ($user)
         </div>
 <?php
             echo sprintf(__('<b>%s</b> posted %s'), $name,
-                sprintf('<time class="relative" datetime="%s" title="%s">%s</time>',
+                sprintf('<time datetime="%s" title="%s">%s</time>',
                     date(DateTime::W3C, Misc::db2gmtime($entry->created)),
                     Format::daydatetime($entry->created),
-                    Format::relativeTime(Misc::db2gmtime($entry->created))
+                    Format::datetime($entry->created)
                 )
             ); ?>
             <span style="max-width:500px" class="faded title truncate"><?php

--- a/include/i18n/en_US/help/tips/settings.agents.yaml
+++ b/include/i18n/en_US/help/tips/settings.agents.yaml
@@ -21,6 +21,12 @@ agent_name_format:
         Choose a format for Agents names throughout the system. Email templates
         will use it for names if no other format is specified.
 
+staff_identity_masking:
+    title: Staff Identity Masking
+    content: >
+        If enabled, this will hide the Agent’s name from the Client during any
+        communication.
+
 # Authentication settings
 password_reset:
     title: Password Expiration Policy

--- a/include/i18n/en_US/help/tips/settings.ticket.yaml
+++ b/include/i18n/en_US/help/tips/settings.ticket.yaml
@@ -108,12 +108,6 @@ answered_tickets:
         will be included in the <span class="doc-desc-title">Open Tickets
         Queue</span>.
 
-staff_identity_masking:
-    title: Staff Identity Masking
-    content: >
-        If enabled, this will hide the Agent’s name from the Client during any
-        communication.
-
 ticket_attachment_settings:
     title: Ticket Thread Attachments
     content: >

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -208,7 +208,9 @@ if ($avatar->isChangeable()) { ?>
                            'email' => __("Email Address Name"),
                            'dept' => sprintf(__("Department Name (%s)"),
                                __('if public' /* This is used in 'Department's Name (>if public<)' */)),
-                           'mine' => __('My Name'));
+                           'mine' => __('My Name'),
+                           '' => '— '.__('System Default').' —',
+                           );
                   if ($cfg->hideStaffName())
                     unset($options['mine']);
 
@@ -274,6 +276,23 @@ if ($avatar->isChangeable()) { ?>
                 $TZ_TIMEZONE = $staff->timezone;
                 include STAFFINC_DIR.'templates/timezone.tmpl.php'; ?>
                 <div class="error"><?php echo $errors['timezone']; ?></div>
+            </td>
+        </tr>
+        <tr><td><?php echo __('Time Format');?>:</td>
+            <td>
+                <select name="datetime_format">
+<?php
+    $datetime_format = $staff->datetime_format;
+    foreach (array(
+    'relative' => __('Relative Time'),
+    '' => '— '.__('System Default').' —',
+) as $v=>$name) { ?>
+                    <option value="<?php echo $v; ?>" <?php
+                    if ($v == $datetime_format)
+                        echo 'selected="selected"';
+                    ?>><?php echo $name; ?></option>
+<?php } ?>
+                </select>
             </td>
         </tr>
 <?php if ($cfg->getSecondaryLanguages()) { ?>

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -223,7 +223,29 @@ if ($avatar->isChangeable()) { ?>
                 <div class="error"><?php echo $errors['default_from_name']; ?></div>
             </td>
         </tr>
-
+        <tr>
+            <td><?php echo __('Thread View Order');?>:
+              <div class="faded"><?php echo __('The order of thread entries');?></div>
+            </td>
+            <td>
+                <select name="thread_view_order">
+                  <?php
+                   $options=array(
+                           'desc' => __('Descending'),
+                           'asc' => __('Ascending'),
+                           '' => '— '.__('System Default').' —',
+                           );
+                  foreach($options as $k=>$v) {
+                      echo sprintf('<option value="%s" %s>%s</option>',
+                                $k
+                                ,($staff->thread_view_order == $k) ? 'selected="selected"' : ''
+                                ,$v);
+                  }
+                  ?>
+                </select>
+                <div class="error"><?php echo $errors['thread_view_order']; ?></div>
+            </td>
+        </tr>
         <tr>
             <td><?php echo __('Default Signature');?>:
               <div class="faded"><?php echo __('This can be selected when replying to a thread');?></div>

--- a/include/staff/profile.inc.php
+++ b/include/staff/profile.inc.php
@@ -196,9 +196,35 @@ if ($avatar->isChangeable()) { ?>
                 </select>
             </td>
         </tr>
+
+        <tr>
+            <td><?php echo __('Default From Name');?>:
+              <div class="faded"><?php echo __('From name to use when replying to a thread');?></div>
+            </td>
+            <td>
+                <select name="default_from_name">
+                  <?php
+                   $options=array(
+                           'email' => __("Email Address Name"),
+                           'dept' => sprintf(__("Department Name (%s)"),
+                               __('if public' /* This is used in 'Department's Name (>if public<)' */)),
+                           'mine' => __('My Name'));
+                  if ($cfg->hideStaffName())
+                    unset($options['mine']);
+
+                  foreach($options as $k=>$v) {
+                      echo sprintf('<option value="%s" %s>%s</option>',
+                                $k,($staff->default_from_name==$k)?'selected="selected"':'',$v);
+                  }
+                  ?>
+                </select>
+                <div class="error"><?php echo $errors['default_from_name']; ?></div>
+            </td>
+        </tr>
+
         <tr>
             <td><?php echo __('Default Signature');?>:
-              <div class="faded"><?php echo __('This can be selected when replying to a ticket');?></div>
+              <div class="faded"><?php echo __('This can be selected when replying to a thread');?></div>
             </td>
             <td>
                 <select name="default_signature_type">

--- a/include/staff/settings-agents.inc.php
+++ b/include/staff/settings-agents.inc.php
@@ -36,6 +36,14 @@ if (!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config
                         </td>
                     </tr>
                     <tr>
+                        <td><?php echo __('Agent Identity Masking'); ?>:</td>
+                        <td>
+                            <input type="checkbox" name="hide_staff_name" <?php echo $config['hide_staff_name']?'checked="checked"':''; ?>>
+                            <?php echo __("Hide agent's name on responses."); ?>
+                            <i class="help-tip icon-question-sign" href="#staff_identity_masking"></i>
+                        </td>
+                    </tr>
+                    <tr>
                         <td width="180"><?php echo __('Avatar Source'); ?>:</td>
                         <td>
                             <select name="agent_avatar">

--- a/include/staff/settings-tickets.inc.php
+++ b/include/staff/settings-tickets.inc.php
@@ -204,14 +204,6 @@ if(!($maxfileuploads=ini_get('max_file_uploads')))
             </td>
         </tr>
         <tr>
-            <td><?php echo __('Agent Identity Masking'); ?>:</td>
-            <td>
-                <input type="checkbox" name="hide_staff_name" <?php echo $config['hide_staff_name']?'checked="checked"':''; ?>>
-                <?php echo __("Hide agent's name on responses."); ?>
-                <i class="help-tip icon-question-sign" href="#staff_identity_masking"></i>
-            </td>
-        </tr>
-        <tr>
             <th colspan="2">
                 <em><b><?php echo __('Attachments');?></b>:  <?php echo __('Size and maximum uploads setting mainly apply to web tickets.');?></em>
             </th>

--- a/include/staff/templates/task-view.tmpl.php
+++ b/include/staff/templates/task-view.tmpl.php
@@ -311,7 +311,8 @@ if (!$ticket) { ?>
      $task->getThread()->render(array('M', 'R', 'N'),
              array(
                  'mode' => Thread::MODE_STAFF,
-                 'container' => 'taskThread'
+                 'container' => 'taskThread',
+                 'sort' => $thisstaff->thread_view_order
                  )
              );
      ?>

--- a/include/staff/templates/thread-entry.tmpl.php
+++ b/include/staff/templates/thread-entry.tmpl.php
@@ -1,4 +1,12 @@
 <?php
+global $thisstaff;
+$timeFormat = null;
+if ($thisstaff && !strcasecmp($thisstaff->datetime_format, 'relative')) {
+    $timeFormat = function($datetime) {
+        return Format::relativeTime(Misc::db2gmtime($datetime));
+    };
+}
+
 $entryTypes = array('M'=>'message', 'R'=>'response', 'N'=>'note');
 $user = $entry->getUser() ?: $entry->getStaff();
 $name = $user ? $user->getName() : $entry->poster;
@@ -51,16 +59,17 @@ if ($user)
         </span>
         </div>
 <?php
-        echo sprintf(__('<b>%s</b> posted %s'),
-                $entry->isSystem() ?  __('SYSTEM') : $name,
-            sprintf('<a name="entry-%d" href="#entry-%1$s"><time class="relative" datetime="%s" title="%s">%s</time></a>',
+        echo sprintf(__('<b>%s</b> posted %s'), $name,
+            sprintf('<a name="entry-%d" href="#entry-%1$s"><time %s
+                datetime="%s" data-toggle="tooltip" title="%s">%s</time></a>',
                 $entry->id,
+                $timeFormat ? 'class="relative"' : '',
                 date(DateTime::W3C, Misc::db2gmtime($entry->created)),
                 Format::daydatetime($entry->created),
-                Format::relativeTime(Misc::db2gmtime($entry->created))
+                $timeFormat ? $timeFormat($entry->created) : Format::datetime($entry->created)
             )
         ); ?>
-        <span style="max-width:500px" class="faded title truncate"><?php
+        <span style="max-width:400px" class="faded title truncate"><?php
             echo $entry->title; ?></span>
         </span>
     </div>

--- a/include/staff/ticket-view.inc.php
+++ b/include/staff/ticket-view.inc.php
@@ -497,8 +497,10 @@ $tcount = $ticket->getThreadEntries($types)->count();
     $ticket->getThread()->render(
             array('M', 'R', 'N'),
             array(
-                'html-id' => 'ticketThread',
-                'mode' => Thread::MODE_STAFF)
+                'html-id'   => 'ticketThread',
+                'mode'      => Thread::MODE_STAFF,
+                'sort'      => $thisstaff->thread_view_order
+                )
             );
 ?>
 <div class="clear"></div>

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -74,7 +74,7 @@ div#header a {
 time[title]:hover {
     text-decoration: underline;
 }
-a time.relative {
+a time {
     color: initial;
 }
 


### PR DESCRIPTION
This pull requests adds two preferences to agent's profile. To avoid a database patch, global Config table is being used to store the preferences (which requires an extra lookup trip to the database after the object loads).

__Add option to use department's or agent's name on replies__
Enable the ability to use the agent's full name or department's name on responses/replies in addition to the emails address name. 

Email address of the response would still be the designated outgoing email address of the department to which the ticket/task is assigned or the system default outgoing email address.

* Agents can set the default FROM Name in Profile > Preference.
* Private department's name won't be used regardless of the setting.
* Agent's name won't be used if identity masking is enabled.

__Option to disable Relative Time__
Starting with v1.10-RCx we added the ability to show realtime relative-time (e.g 2 minutes ago) on ticket thread with the actual date-time shown on moreover. The feedback from the core osTicket users has been negative -- this pull request makes the feature optional via agent's profile.


__Thread View Sort Order__
Add a preference option to set the sort order of the thread entries in DESC or
ASC order.

 * System Default order is ASC.
 * Auto-scroll is disabled when sort order is set to DESC.
