### PR TITLE
Make Avatars optional on thread view

### DIFF
--- a/include/class.config.php
+++ b/include/class.config.php
@@ -162,6 +162,7 @@ class OsticketConfig extends Config {
         'allow_pw_reset' =>     true,
         'pw_reset_window' =>    30,
         'enable_richtext' =>    true,
+        'enable_avatars' =>     true,
         'allow_attachments' =>  true,
         'agent_name_format' =>  'full', # First Last
         'client_name_format' => 'original', # As entered
@@ -378,6 +379,10 @@ class OsticketConfig extends Config {
 
     function isRichTextEnabled() {
         return $this->get('enable_richtext');
+    }
+
+    function isAvatarsEnabled() {
+        return $this->get('enable_avatars');
     }
 
     function getClientTimeout() {
@@ -1112,6 +1117,7 @@ class OsticketConfig extends Config {
             'secondary_langs'=>$secondary_langs,
             'max_file_size' => $vars['max_file_size'],
             'autolock_minutes' => $vars['autolock_minutes'],
+            'enable_avatars' => isset($vars['enable_avatars']) ? 1 : 0,
             'enable_richtext' => isset($vars['enable_richtext']) ? 1 : 0,
         ));
     }

--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -1610,15 +1610,18 @@ class ThreadEvent extends VerySimpleModel {
     }
 
     function template($description) {
-        global $thisstaff;
+        global $thisstaff, $cfg;
+
         $self = $this;
         return preg_replace_callback('/\{(<(?P<type>([^>]+))>)?(?P<key>[^}.]+)(\.(?P<data>[^}]+))?\}/',
-            function ($m) use ($self, $thisstaff) {
+            function ($m) use ($self, $thisstaff, $cfg) {
                 switch ($m['key']) {
                 case 'assignees':
                     $assignees = array();
                     if ($S = $self->staff) {
-                        $avatar = $S->getAvatar();
+                        $avatar = '';
+                        if ($cfg->isAvatarsEnabled())
+                            $avatar = $S->getAvatar();
                         $assignees[] =
                             $avatar.$S->getName();
                     }
@@ -1628,7 +1631,8 @@ class ThreadEvent extends VerySimpleModel {
                     return implode('/', $assignees);
                 case 'somebody':
                     $name = $self->getUserName();
-                    if ($avatar = $self->getAvatar())
+                    if ($cfg->isAvatarsEnabled()
+                            && ($avatar = $self->getAvatar()))
                         $name = $avatar.$name;
                     return $name;
                 case 'timestamp':
@@ -1651,7 +1655,8 @@ class ThreadEvent extends VerySimpleModel {
                     );
                 case 'agent':
                     $name = $self->agent->getName();
-                    if ($avatar = $self->getAvatar())
+                    if ($cfg->isAvatarsEnabled()
+                            && ($avatar = $self->getAvatar()))
                         $name = $avatar.$name;
                     return $name;
                 case 'dept':

--- a/include/client/templates/thread-entry.tmpl.php
+++ b/include/client/templates/thread-entry.tmpl.php
@@ -1,9 +1,10 @@
 <?php
+global $cfg;
 $entryTypes = array('M'=>'message', 'R'=>'response', 'N'=>'note');
 $user = $entry->getUser() ?: $entry->getStaff();
 $name = $user ? $user->getName() : $entry->poster;
 $avatar = '';
-if ($user)
+if ($cfg->isAvatarsEnabled() && $user)
     $avatar = $user->getAvatar();
 ?>
 

--- a/include/i18n/en_US/help/tips/settings.system.yaml
+++ b/include/i18n/en_US/help/tips/settings.system.yaml
@@ -72,6 +72,19 @@ enable_richtext:
         If enabled, this will permit the use of rich text formatting between
         Clients and Agents.
 
+enable_avatars:
+    title: Enable Avatars on Thread View
+    content: >
+        Enable this to show <span class="doc-desc-title">Avatars</span> on thread correspondence.
+        <br><br>
+        The <span class="doc-desc-title">Avatar Source</span> can be set in Agents' and Users' settings pages.
+    links:
+      - title: Agents Settings
+        href: /scp/settings.php?t=agents
+
+      - title: Users Settings
+        href: /scp/settings.php?t=users
+
 collision_avoidance:
     title: Agent Collision Avoidance
     content: >

--- a/include/staff/settings-system.inc.php
+++ b/include/staff/settings-system.inc.php
@@ -69,16 +69,6 @@ $gmtime = Misc::gmtime();
                 &nbsp;<i class="help-tip icon-question-sign" href="#collision_avoidance"></i>
             </td>
         </tr>
-        <tr>
-            <td><?php echo __('Enable Rich Text'); ?>:</td>
-            <td>
-                <input type="checkbox" name="enable_richtext" <?php
-                echo $config['enable_richtext']?'checked="checked"':''; ?>>
-                <?php echo __('Enable html in thread entries and email correspondence.'); ?>
-                <i class="help-tip icon-question-sign" href="#enable_richtext"></i>
-            </td>
-        </tr>
-
         <tr><td><?php echo __('Default Page Size');?>:</td>
             <td>
                 <select name="max_page_size">
@@ -121,6 +111,24 @@ $gmtime = Misc::gmtime();
                     } ?>
                 </select>
                 <i class="help-tip icon-question-sign" href="#purge_logs"></i>
+            </td>
+        </tr>
+        <tr>
+            <td><?php echo __('Show Avatars'); ?>:</td>
+            <td>
+                <input type="checkbox" name="enable_avatars" <?php
+                echo $config['enable_avatars'] ? 'checked="checked"' : ''; ?>>
+                <?php echo __('Show Avatars on thread view.'); ?>
+                <i class="help-tip icon-question-sign" href="#enable_avatars"></i>
+            </td>
+        </tr>
+        <tr>
+            <td><?php echo __('Enable Rich Text'); ?>:</td>
+            <td>
+                <input type="checkbox" name="enable_richtext" <?php
+                echo $config['enable_richtext'] ? 'checked="checked"' : ''; ?>>
+                <?php echo __('Enable html in thread entries and email correspondence.'); ?>
+                <i class="help-tip icon-question-sign" href="#enable_richtext"></i>
             </td>
         </tr>
         <tr>

--- a/include/staff/templates/thread-entry.tmpl.php
+++ b/include/staff/templates/thread-entry.tmpl.php
@@ -1,5 +1,5 @@
 <?php
-global $thisstaff;
+global $thisstaff, $cfg;
 $timeFormat = null;
 if ($thisstaff && !strcasecmp($thisstaff->datetime_format, 'relative')) {
     $timeFormat = function($datetime) {
@@ -11,7 +11,7 @@ $entryTypes = array('M'=>'message', 'R'=>'response', 'N'=>'note');
 $user = $entry->getUser() ?: $entry->getStaff();
 $name = $user ? $user->getName() : $entry->poster;
 $avatar = '';
-if ($user)
+if ($user && $cfg->isAvatarsEnabled())
     $avatar = $user->getAvatar();
 ?>
 <div class="thread-entry <?php


### PR DESCRIPTION
Add a global option to disable avatars on thread correspondence . Agent's and user's profiles will still show an avatars.