### PR TITLE
Flag SYSTEM thread entries

### DIFF
--- a/include/class.thread.php
+++ b/include/class.thread.php
@@ -594,6 +594,7 @@ implements TemplateVariable {
 
     const FLAG_COLLABORATOR             = 0x0020;   // Message from collaborator
     const FLAG_BALANCED                 = 0x0040;   // HTML does not need to be balanced on ::display()
+    const FLAG_SYSTEM                   = 0x0080;   // Entry is a system note.
 
     const PERM_EDIT     = 'thread.edit';
 
@@ -869,6 +870,10 @@ implements TemplateVariable {
     }
     function setFlag($flag) {
         return $this->set('flags', $this->get('flags') | $flag);
+    }
+
+    function isSystem() {
+        return $this->hasFlag(self::FLAG_SYSTEM);
     }
 
     //Web uploads - caller is expected to format, validate and set any errors.
@@ -1360,6 +1365,10 @@ implements TemplateVariable {
         if ($entry->format == 'html')
             // The current codebase properly balances html
             $entry->flags |= self::FLAG_BALANCED;
+
+        // Flag system messages
+        if (!($vars['staffId'] || $vars['userId']))
+            $entry->flags |= self::FLAG_SYSTEM;
 
         if (!isset($vars['attachments']) || !$vars['attachments'])
             // Otherwise, body will be configured in a block below (after

--- a/include/staff/templates/thread-entry.tmpl.php
+++ b/include/staff/templates/thread-entry.tmpl.php
@@ -5,9 +5,9 @@ $name = $user ? $user->getName() : $entry->poster;
 $avatar = '';
 if ($user)
     $avatar = $user->getAvatar();
-
 ?>
-<div class="thread-entry <?php echo $entryTypes[$entry->type]; ?> <?php if ($avatar) echo 'avatar'; ?>">
+<div class="thread-entry <?php
+    echo $entry->isSystem() ? 'system' : $entryTypes[$entry->type]; ?> <?php if ($avatar) echo 'avatar'; ?>">
 <?php if ($avatar) { ?>
     <span class="<?php echo ($entry->type == 'M') ? 'pull-right' : 'pull-left'; ?> avatar">
 <?php echo $avatar; ?>
@@ -51,7 +51,8 @@ if ($user)
         </span>
         </div>
 <?php
-        echo sprintf(__('<b>%s</b> posted %s'), $name,
+        echo sprintf(__('<b>%s</b> posted %s'),
+                $entry->isSystem() ?  __('SYSTEM') : $name,
             sprintf('<a name="entry-%d" href="#entry-%1$s"><time class="relative" datetime="%s" title="%s">%s</time></a>',
                 $entry->id,
                 date(DateTime::W3C, Misc::db2gmtime($entry->created)),

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -995,9 +995,10 @@ img.avatar {
     border-left: none;
     border-right: 8px solid #CCC;
 }
-.thread-entry.note:not(.avatar) .header {
+.thread-entry.system .header {
     background-color: #f4f4f4;
 }
+
 .thread-entry.avatar.response .header:before {
     border-right-color: #ccb3af;
 }


### PR DESCRIPTION
This is necessary to differentiate true system notes vs. notes made by deleted agent or collaborator (user). 

The change will help also make SYSTEM as a poster name translatable.

__Pending__
 * [ ]  Flag prior entries with poster set to SYSTEM