### PR TITLE
UI Utility navigation and profile block.

### DIFF
--- a/include/staff/header.inc.php
+++ b/include/staff/header.inc.php
@@ -58,21 +58,37 @@ if ($lang) {
         echo sprintf('<div id="notice_bar">%s</div>', $ost->getNotice());
     ?>
     <div id="header">
-        <p id="info" class="pull-right no-pjax"><?php echo sprintf(__('Welcome, %s.'), '<strong>'.$thisstaff->getFirstName().'</strong>'); ?>
+        
+        
+        
+        <ul id="info" class="pull-right no-pjax">
+            <li>
+                Welcome, <a class="no-pjax" data-dropdown="#profile-dropdown"><strong>John</strong> <i class="icon-sort-down"></i></a>
+            </li>
+            <li><a class="no-pjax" data-dropdown="#utility-dropdown"><i class="icon-th"></i></a></li>
+            <li><a class="no-pjax"><i class="icon-signout"></i></a></li>
+        </ul>       
+        
+        
+        <!--
+        <p id="info" class="pull-right no-pjax"><?php //echo sprintf(__('Welcome, %s.'), '<strong>'.$thisstaff->getFirstName().'</strong>'); ?>
            <?php
-            if($thisstaff->isAdmin() && !defined('ADMINPAGE')) { ?>
-            | <a href="admin.php" class="no-pjax"><?php echo __('Admin Panel'); ?></a>
-            <?php }else{ ?>
-            | <a href="index.php" class="no-pjax"><?php echo __('Agent Panel'); ?></a>
-            <?php } ?>
-            | <a href="profile.php"><?php echo __('Profile'); ?></a>
-            | <a href="logout.php?auth=<?php echo $ost->getLinkToken(); ?>" class="no-pjax"><?php echo __('Log Out'); ?></a>
-        </p>
+            //if($thisstaff->isAdmin() && !defined('ADMINPAGE')) { ?>
+            | <a href="admin.php" class="no-pjax"><?php //echo __('Admin Panel'); ?></a>
+            <?php //}else{ ?>
+            | <a href="index.php" class="no-pjax"><?php //echo __('Agent Panel'); ?></a>
+            <?php //} ?>
+            | <a href="profile.php"><?php //echo __('Profile'); ?></a>
+            | <a href="logout.php?auth=<?php //echo $ost->getLinkToken(); ?>" class="no-pjax"><?php //echo __('Log Out'); ?></a>
+        </p>-->
         <a href="index.php" class="no-pjax" id="logo">
             <span class="valign-helper"></span>
             <img src="logo.php?<?php echo strtotime($cfg->lastModified('staff_logo_id')); ?>" alt="osTicket &mdash; <?php echo __('Customer Support System'); ?>"/>
         </a>
     </div>
+    
+    
+    
     <div id="pjax-container" class="<?php if ($_POST) echo 'no-pjax'; ?>">
 <?php } else {
     header('X-PJAX-Version: ' . GIT_VERSION);
@@ -105,3 +121,56 @@ if ($lang) {
             <div class="<?php echo strtolower($M->getLevel()); ?>-banner"><?php
                 echo (string) $M; ?></div>
 <?php   } ?>
+
+    <div id="profile-dropdown" class="utility-profile action-dropdown anchor-right">
+        <ul class="bleed-left">
+            <li class="profile-info">
+                <div class="avatar pull-left">
+                    <img class="avatar" alt="Avatar" src="/avatar.php?uid=0ea9072b3cc514337faa291cf8e466c3&amp;mode=ateam" data-pin-nopin="true">
+                </div>
+                <div class="profile-group pull-left">
+                    <h3>John Smith</h3>
+                    <p>Marketing</p>
+                    <a class="action-button">View Profile</a>
+                </div>
+                <div class="clear"></div>
+            </li>
+            <li class="profile-team clear">
+                <p>Team(s):<a>Team Awesome</a></p>
+            </li>
+            <li class="profile-activity">
+                    <div class="activity-item">
+                        <span>942</span>Tickets Assigned
+                    </div>
+                    <div class="activity-item">
+                        <span>20</span>Tickets Answered
+                    </div>
+                    <div class="activity-item">
+                        <span>6</span>Tasks Completed
+                    </div>
+            </li>
+            <li class="utility-footer">
+                    <p>Last Login: <span>2 days ago</span></p>
+            </li>
+        </ul>
+    </div> 
+
+    <div id="utility-dropdown" class="utility-nav action-dropdown anchor-right">
+        <ul class="bleed-left">
+            <li class="active">
+                <a href="#"><i class="icon-fixed-width icon-user"></i> Agent Panel</a>
+            </li>
+            <li>
+                <a href="#"><i class="icon-fixed-width icon-gears"></i> Admin Panel</a>
+            </li>
+            <li>
+                <a href="#"><i class="icon-fixed-width icon-folder-open"></i> Account Panel</a>
+            </li>
+            <li>
+                <a href="#"><i class="icon-fixed-width icon-question-sign"></i> Need Help?</a>
+            </li>
+            <li class="utility-footer">
+                <a href="#"><i class="icon-fixed-width icon-bug"></i> Report a problem</a>
+            </li>
+        </ul>    
+    </div>    

--- a/scp/css/scp.css
+++ b/scp/css/scp.css
@@ -163,8 +163,10 @@ a time.relative {
     display: inline-block;
     vertical-align: middle;
 }
-
-#header p {
+/**************************
+    Utility Navigation
+***************************/
+#header ul {
     display:block;
     width:auto;
     max-width:630px;
@@ -173,7 +175,144 @@ a time.relative {
     border:1px solid #ccc;
     padding:8px;
     text-align:center;
+    color:#555;
 }
+
+#header ul li {
+    display:inline-block;
+    margin:0 2px;
+}
+
+#header ul li:first-child, #header ul li:last-child {
+    margin:0;
+}
+
+#header ul li > a {
+    padding:0 6px;
+    margin:0;
+    color:#555;
+    text-decoration:none;
+}
+#header ul li > a:hover {
+    color:#E65524;
+}
+#header ul li:first-child > a {
+    padding:0 9px 0 0;
+}
+#header ul li:last-child > a {
+    padding:0;
+}
+#header ul li:first-child:after {
+    content:"";
+    border-right:1px solid #666;
+    display:inline-block;
+    padding:10px 0;
+    margin-bottom:-5px;
+}
+.utility-profile.action-dropdown > ul, .utility-nav.action-dropdown > ul {
+    padding:10px 0 0 0;
+}
+.utility-profile.action-dropdown > ul > li {
+    padding:0 10px;
+    margin-bottom:10px;
+}
+.utility-profile.action-dropdown > ul > li:last-child {
+    margin-bottom:0px;
+}
+
+.utility-profile.action-dropdown li.profile-info .avatar {
+    width:70px;
+}
+    /***/
+
+    .profile-group {
+        padding:0 10px;
+    }
+    .profile-group h3 {
+        padding:0;
+        margin:0;
+    }
+    .profile-group p {
+        padding:0;
+        margin:0;
+        color:#666;
+    }
+    .profile-group a.action-button {
+        margin:5px 0 0 0 !IMPORTANT;
+        width:100%;
+        padding:2px 0!IMPORTANT;
+        text-align:center;
+    }
+
+    /***/
+
+    .profile-team {
+        border-top:1px dotted #999;
+        border-bottom:1px dotted #999;
+        display:block;
+    }
+
+    .profile-team p {
+        margin:0;
+        padding:5px 0;
+    }
+
+    .profile-team a {
+        color:#666;
+        text-decoration:underline;
+        margin:0 4px;
+    }
+
+    .profile-team a:hover {
+        color:#E65524;
+    }
+
+    /***/
+
+    .profile-activity .activity-item {
+        padding:5px 0;
+        color:#666;
+    }
+
+    .profile-activity .activity-item span {
+        min-width:30px;
+        display:inline-block;
+        color:#666;
+        text-align:right;
+        margin:0 5px;
+        color:#E65524;
+        font-weight:bold;
+    }
+
+    /***/
+
+.utility-footer {
+    border-top:1px dotted #999;
+    background-color:#f4f4f4;
+    border-bottom-left-radius:6px;
+    border-bottom-right-radius:6px;
+    text-align:center;
+}
+
+.utility-footer > p {
+    margin:0;
+    padding:15px;
+}
+
+.utility-footer p > span {
+    color:#E65524;
+    font-weight:bold;
+    margin: 0 2px;
+}
+.utility-footer > a {
+    text-decoration: none;
+    padding:10px!IMPORTANT;
+    display:block;
+    border-bottom-left-radius:6px;
+    border-bottom-right-radius:6px;
+}
+
+/**************************/
 
 #nav, #sub_nav {
     clear:both;


### PR DESCRIPTION
UI Prototype changes the layout and function of the top right corner
navigation. Creates a profile panel with information related to the
Agent and a link to the Agents full profile. Also moves the Agent,
Admin, and Account navigation into a drop down with the possibility for
future expansion to the navigation. i.e. Report a bug that allows
admins to submit tickets directly to the osTicket Team. Or access help
information. Ideally admins could add their own custom navigation under
the primary links.

TO-DO:
1. needs Php, it’s only HTML and CSS right now.

Screen shots:
![screen shot 2015-11-04 at 3 25 38 pm](https://cloud.githubusercontent.com/assets/8247872/10952839/649d1bb4-830a-11e5-9206-908d2693f812.png)
![screen shot 2015-11-04 at 3 25 10 pm](https://cloud.githubusercontent.com/assets/8247872/10952811/4c985a4c-830a-11e5-9538-62aceda0cfad.png)
![screen shot 2015-11-04 at 3 24 58 pm](https://cloud.githubusercontent.com/assets/8247872/10952808/4c9082f4-830a-11e5-8945-9e33f4dde213.png)
![screen shot 2015-11-04 at 3 25 18 pm](https://cloud.githubusercontent.com/assets/8247872/10952810/4c95ef78-830a-11e5-82ca-e14f23970601.png)
![screen shot 2015-11-04 at 3 25 27 pm](https://cloud.githubusercontent.com/assets/8247872/10952812/4c99c9b8-830a-11e5-9d50-136f8666a1ed.png)
![screen shot 2015-11-04 at 3 25 55 pm](https://cloud.githubusercontent.com/assets/8247872/10952809/4c947f9e-830a-11e5-804e-8bf4080781c4.png)