### PR TITLE
Make Authentication Tokens Optional

### DIFF
--- a/include/class.auth.php
+++ b/include/class.auth.php
@@ -1044,6 +1044,11 @@ class AuthTokenAuthentication extends UserAuthenticationBackend {
 
 
     function signOn() {
+        global $cfg;
+
+
+        if (!$cfg || !$cfg->isAuthTokenEnabled())
+            return null;
 
         $user = null;
         if ($_GET['auth']) {
@@ -1119,7 +1124,9 @@ class AuthTokenAuthentication extends UserAuthenticationBackend {
     }
 
 }
-UserAuthenticationBackend::register('AuthTokenAuthentication');
+
+if ($cfg && $cfg->isAuthTokenEnabled())
+    UserAuthenticationBackend::register('AuthTokenAuthentication');
 
 //Simple ticket lookup backend used to recover ticket access link.
 // We're using authentication backend so we can guard aganist brute force

--- a/include/class.client.php
+++ b/include/class.client.php
@@ -41,12 +41,14 @@ implements EmailContact, ITicketUser, TemplateVariable {
         $tag =  substr($name, 3);
         switch (strtolower($tag)) {
             case 'ticket_link':
+                $qstr = array();
+                if ($cfg && $cfg->isAuthTokenEnabled()
+                        && ($ticket=$this->getTicket()))
+                    $qstr['auth'] = $ticket->getAuthToken($this);
+
                 return sprintf('%s/view.php?%s',
                         $cfg->getBaseUrl(),
-                        Http::build_query(
-                            array('auth' => $this->getTicket()->getAuthToken($this)),
-                            false
-                            )
+                        Http::build_query($qstr, false)
                         );
                 break;
         }
@@ -64,7 +66,7 @@ implements EmailContact, ITicketUser, TemplateVariable {
         return array(
             'email' => __('Email address'),
             'name' => array('class' => 'PersonsName', 'desc' => __('Full name')),
-            'ticket_link' => __('Auth. token used for auto-login'),
+            'ticket_link' => __('Link to view the ticket'),
         );
     }
 

--- a/include/class.client.php
+++ b/include/class.client.php
@@ -36,25 +36,7 @@ implements EmailContact, ITicketUser, TemplateVariable {
                 ? call_user_func_array(array($this->user, $name), $args)
                 : call_user_func(array($this->user, $name));
 
-        if ($rv) return $rv;
-
-        $tag =  substr($name, 3);
-        switch (strtolower($tag)) {
-            case 'ticket_link':
-                $qstr = array();
-                if ($cfg && $cfg->isAuthTokenEnabled()
-                        && ($ticket=$this->getTicket()))
-                    $qstr['auth'] = $ticket->getAuthToken($this);
-
-                return sprintf('%s/view.php?%s',
-                        $cfg->getBaseUrl(),
-                        Http::build_query($qstr, false)
-                        );
-                break;
-        }
-
-        return false;
-
+        return $rv ?: false;
     }
 
     // Required for Internationalization::getCurrentLanguage() in templates
@@ -68,6 +50,22 @@ implements EmailContact, ITicketUser, TemplateVariable {
             'name' => array('class' => 'PersonsName', 'desc' => __('Full name')),
             'ticket_link' => __('Link to view the ticket'),
         );
+    }
+
+    function getVar($tag) {
+        switch (strtolower($tag)) {
+        case 'ticket_link':
+            $qstr = array();
+            if ($cfg && $cfg->isAuthTokenEnabled()
+                    && ($ticket=$this->getTicket()))
+                $qstr['auth'] = $ticket->getAuthToken($this);
+
+            return sprintf('%s/view.php?%s',
+                    $cfg->getBaseUrl(),
+                    Http::build_query($qstr, false)
+                    );
+            break;
+        }
     }
 
     function getId() { return ($this->user) ? $this->user->getId() : null; }

--- a/include/class.config.php
+++ b/include/class.config.php
@@ -173,6 +173,7 @@ class OsticketConfig extends Config {
         'default_help_topic' => 0,
         'help_topic_sort_mode' => 'a',
         'client_verify_email' => 1,
+        'allow_auth_tokens' => 1,
         'verify_email_addrs' => 1,
         'client_avatar' => 'gravatar.mm',
         'agent_avatar' => 'gravatar.mm',
@@ -657,6 +658,10 @@ class OsticketConfig extends Config {
 
     function isClientEmailVerificationRequired() {
         return $this->get('client_verify_email');
+    }
+
+    function isAuthTokenEnabled() {
+        return $this->get('allow_auth_tokens');
     }
 
     function isCaptchaEnabled() {
@@ -1159,6 +1164,7 @@ class OsticketConfig extends Config {
             'clients_only'=>isset($vars['clients_only'])?1:0,
             'client_registration'=>$vars['client_registration'],
             'client_verify_email'=>isset($vars['client_verify_email'])?1:0,
+            'allow_auth_tokens' => isset($vars['allow_auth_tokens']) ? 1 : 0,
             'client_name_format'=>$vars['client_name_format'],
             'client_avatar'=>$vars['client_avatar'],
         ));

--- a/include/class.http.php
+++ b/include/class.http.php
@@ -122,8 +122,14 @@ class Http {
     }
 
     static function build_query($vars, $encode=true, $separator='&amp;') {
-        return http_build_query(
-                ($encode ? Format::htmlchars($vars) : $vars), '', $separator);
+
+        if (!$vars)
+            return '';
+
+        if ($encode)
+            $vars = Format::htmlchars($vars);
+
+        return http_build_query($vars, '', $separator);
     }
 }
 ?>

--- a/include/i18n/en_US/help/tips/settings.users.yaml
+++ b/include/i18n/en_US/help/tips/settings.users.yaml
@@ -71,3 +71,8 @@ client_verify_email:
         <br><br>
         Disabling email verification might allow third-parties (e.g. ticket
         collaborators) to impersonate the ticket owner.
+
+allow_auth_tokens:
+    title: Enable Authentication Tokens
+    content: >
+        Enable this option to allow use of authentication tokens to auto-login users on ticket link click.

--- a/include/staff/settings-users.inc.php
+++ b/include/staff/settings-users.inc.php
@@ -116,6 +116,14 @@ if(!defined('OSTADMININC') || !$thisstaff || !$thisstaff->isAdmin() || !$config)
               <i class="help-tip icon-question-sign" href="#client_session_timeout"></i>
             </td>
         </tr>
+        <tr><td><?php echo __('Authentication Token'); ?>:</td>
+            <td><input type="checkbox" name="allow_auth_tokens" <?php
+                if ($config['allow_auth_tokens'])
+                    echo 'checked="checked"'; ?>/> <?php
+                    echo __('Enable use of authentication tokens to auto-login users'); ?>
+            <i class="help-tip icon-question-sign" href="#allow_auth_tokens"></i>
+            </td>
+        </tr>
         <tr><td><?php echo __('Client Quick Access'); ?>:</td>
             <td><input type="checkbox" name="client_verify_email" <?php
                 if ($config['client_verify_email'])


### PR DESCRIPTION
Add ability to disable use of authentication tokens on ticket links. 

__Note__: Disabling auth-tokens effectively kills Guest Ticket Access email verification mechanism. Use of difference link variable might be necessary.