### PR TITLE
bug: In-Reply-To and References headers

### DIFF
--- a/include/class.task.php
+++ b/include/class.task.php
@@ -675,10 +675,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
             // Send the alerts.
             $sentlist = array();
             $options = $note instanceof ThreadEntry
-                ? array(
-                    'inreplyto' => $note->getEmailMessageId(),
-                    'references' => $note->getEmailReferences(),
-                    'thread' => $note)
+                ? array('thread' => $note)
                 : array();
 
             foreach ($recipients as $k => $staff) {
@@ -765,10 +762,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
 
             $sentlist = $options = array();
             if ($note instanceof ThreadEntry) {
-                $options += array(
-                    'inreplyto'=>$note->getEmailMessageId(),
-                    'references'=>$note->getEmailReferences(),
-                    'thread'=>$note);
+                $options += array('thread'=>$note);
             }
 
             foreach ($recipients as $k=>$staff) {
@@ -1018,10 +1012,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
         $options = array();
         $staffId = $thisstaff ? $thisstaff->getId() : 0;
         if ($vars['threadentry'] && $vars['threadentry'] instanceof ThreadEntry) {
-            $options = array(
-                'inreplyto' => $vars['threadentry']->getEmailMessageId(),
-                'references' => $vars['threadentry']->getEmailReferences(),
-                'thread' => $vars['threadentry']);
+            $options = array('thread' => $vars['threadentry']);
 
             // Activity details
             if (!$vars['message'])
@@ -1104,8 +1095,7 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
         $msg = $this->replaceVars($msg->asArray(), $vars);
 
         $attachments = $cfg->emailAttachments()?$entry->getAttachments():array();
-        $options = array('inreplyto' => $entry->getEmailMessageId(),
-                         'thread' => $entry);
+        $options = array('thread' => $entry);
 
         foreach ($recipients as $recipient) {
             // Skip folks who have already been included on this part of

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -1246,7 +1246,8 @@ implements RestrictedAccess, Threadable {
         }
 
         $options = array();
-        if ($message instanceof ThreadEntry) {
+        if (($message instanceof ThreadEntry)
+                && $message->getEmailMessageId()) {
             $options += array(
                 'inreplyto'=>$message->getEmailMessageId(),
                 'references'=>$message->getEmailReferences(),
@@ -1434,8 +1435,7 @@ implements RestrictedAccess, Threadable {
         $msg = $this->replaceVars($msg->asArray(), $vars);
 
         $attachments = $cfg->emailAttachments()?$entry->getAttachments():array();
-        $options = array('inreplyto' => $entry->getEmailMessageId(),
-                         'thread' => $entry);
+        $options = array('thread' => $entry);
         foreach ($recipients as $recipient) {
             // Skip folks who have already been included on this part of
             // the conversation
@@ -1523,10 +1523,14 @@ implements RestrictedAccess, Threadable {
                     'signature' => ($dept && $dept->isPublic())?$dept->getSignature():''
                 )
             );
-            $options = array(
-                'inreplyto' => $message->getEmailMessageId(),
-                'thread' => $message
-            );
+            $options = array('thread' => $message);
+            if ($message->getEmailMessageId()) {
+                $options += array(
+                        'inreplyto' => $message->getEmailMessageId(),
+                        'references' => $message->getEmailReferences()
+                        );
+            }
+
             $email->sendAutoReply($user, $msg['subj'], $msg['body'],
                 null, $options);
         }
@@ -1573,10 +1577,7 @@ implements RestrictedAccess, Threadable {
         $options = array();
         $staffId = $thisstaff ? $thisstaff->getId() : 0;
         if ($vars['threadentry'] && $vars['threadentry'] instanceof ThreadEntry) {
-            $options = array(
-                'inreplyto' => $vars['threadentry']->getEmailMessageId(),
-                'references' => $vars['threadentry']->getEmailReferences(),
-                'thread' => $vars['threadentry']);
+            $options = array('thread' => $vars['threadentry']);
 
             // Activity details
             if (!$vars['comments'])
@@ -1671,10 +1672,7 @@ implements RestrictedAccess, Threadable {
             // Send the alerts.
             $sentlist = array();
             $options = $note instanceof ThreadEntry
-                ? array(
-                    'inreplyto'=>$note->getEmailMessageId(),
-                    'references'=>$note->getEmailReferences(),
-                    'thread'=>$note)
+                ? array('thread'=>$note)
                 : array();
             foreach ($recipients as $k=>$staff) {
                 if (!is_object($staff)
@@ -2004,10 +2002,7 @@ implements RestrictedAccess, Threadable {
             }
             $sentlist = $options = array();
             if ($note) {
-                $options += array(
-                    'inreplyto'=>$note->getEmailMessageId(),
-                    'references'=>$note->getEmailReferences(),
-                    'thread'=>$note);
+                $options += array('thread'=>$note);
             }
             foreach ($recipients as $k=>$staff) {
                 if (!is_object($staff)
@@ -2239,7 +2234,7 @@ implements RestrictedAccess, Threadable {
         if ($alerts && $message->isBounceOrAutoReply())
             $alerts = false;
 
-        if ($alerts && $this->getThread()->getLastMessage(array(
+        if ($alerts && $this->getThread()->getLastEmailMessage(array(
             'user_id' => $message->user_id,
             'id__lt' => $message->id,
             'created__gt' => SqlFunction::NOW()->minus(SqlInterval::MINUTE(5)),
@@ -2261,11 +2256,8 @@ implements RestrictedAccess, Threadable {
             'message' => $message,
             'poster' => ($vars['poster'] ? $vars['poster'] : $this->getName())
         );
-        $options = array(
-            'inreplyto' => $message->getEmailMessageId(),
-            'references' => $message->getEmailReferences(),
-            'thread'=>$message
-        );
+
+        $options = array('thread'=>$message);
         // If enabled...send alert to staff (New Message Alert)
         if ($cfg->alertONNewMessage()
             && ($email = $dept->getAlertEmail())
@@ -2374,11 +2366,18 @@ implements RestrictedAccess, Threadable {
             );
             $attachments = ($cfg->emailAttachments() && $files)
                 ? $response->getAttachments() : array();
-            $options = array(
-                'inreplyto'=>$response->getEmailMessageId(),
-                'references'=>$response->getEmailReferences(),
-                'thread'=>$response);
-            $email->sendAutoReply($this, $msg['subj'], $msg['body'], $attachments,
+
+            $options = array('thread' => $response);
+            if (($message instanceof ThreadEntry)
+                    && $message->getUserId() == $this->getUserId()
+                    && ($mid=$message->getEmailMessageId())) {
+                $options += array(
+                        'inreplyto' => $mid,
+                        'references' => $message->getEmailReferences()
+                        );
+            }
+
+            $email->sendAutoReply($this->getOwner(), $msg['subj'], $msg['body'], $attachments,
                 $options);
         }
         return $response;
@@ -2442,21 +2441,19 @@ implements RestrictedAccess, Threadable {
             'staff' => $thisstaff,
             'poster' => $thisstaff
         );
-        $options = array(
-            'inreplyto' => $response->getEmailMessageId(),
-            'references' => $response->getEmailReferences(),
-            'thread'=>$response
-        );
 
+
+        $user = $this->getOwner();
+        $options = array('thread' => $response);
         if (($email=$dept->getEmail())
             && ($tpl = $dept->getTemplate())
             && ($msg=$tpl->getReplyMsgTemplate())
         ) {
             $msg = $this->replaceVars($msg->asArray(),
-                $variables + array('recipient' => $this->getOwner())
+                $variables + array('recipient' => $user)
             );
             $attachments = $cfg->emailAttachments()?$response->getAttachments():array();
-            $email->send($this->getOwner(), $msg['subj'], $msg['body'], $attachments,
+            $email->send($user, $msg['subj'], $msg['body'], $attachments,
                 $options);
         }
 
@@ -3487,14 +3484,8 @@ implements RestrictedAccess, Threadable {
                     'staff'     => $thisstaff,
                 )
             );
-            $references = array();
             $message = $ticket->getLastMessage();
-            if (isset($message))
-                $references[] = $message->getEmailMessageId();
-            if (isset($response))
-                $references[] = $response->getEmailMessageId();
             $options = array(
-                'references' => $references,
                 'thread' => $message ?: $ticket->getThread(),
             );
             $email->send($ticket->getOwner(), $msg['subj'], $msg['body'], $attachments,


### PR DESCRIPTION
Make sure reflected email headers are valid for the recipient.

This PR addresses cases where the wrong thread participant (collaborator) is falsely credited for a message as a result of false-match due to errant in-reply-to and references headers being added haphazardly to outgoing emails.