### PR TITLE
Feature: Snooze tasks and tickets

### DIFF
--- a/include/ajax.tickets.php
+++ b/include/ajax.tickets.php
@@ -891,6 +891,17 @@ class TicketsAjaxAPI extends AjaxController {
 
         if (!$errors && $ticket->setStatus($status, $_REQUEST['comments'], $errors)) {
 
+            /** ugly but ORM looks to complex to me **/
+            if (isset($_POST["snooze"]) && isset($_POST["reopentime"]))
+            {
+                $autoreopen = filter_input(INPUT_POST, "reopentime")." ".filter_input(INPUT_POST, "reopentime:time");
+                db_query("UPDATE ".TICKET_TABLE." SET autoreopen = '$autoreopen' WHERE ticket_id = ".$ticket->getId());
+            }
+            else
+            {
+                db_query("UPDATE ".TICKET_TABLE." SET autoreopen = NULL WHERE ticket_id = ".$ticket->getId());
+            }
+            
             if ($state == 'deleted') {
                 $msg = sprintf('%s %s',
                         sprintf(__('Ticket #%s'), $ticket->getNumber()),

--- a/include/class.cron.php
+++ b/include/class.cron.php
@@ -28,10 +28,16 @@ class Cron {
     function TicketMonitor() {
         require_once(INCLUDE_DIR.'class.ticket.php');
         Ticket::checkOverdue(); //Make stale tickets overdue
+        Ticket::checkAutoreopen();
         // Cleanup any expired locks
         require_once(INCLUDE_DIR.'class.lock.php');
         Lock::cleanup();
 
+    }
+    
+    function TaskMonitor() {
+        require_once(INCLUDE_DIR.'class.task.php');
+        Task::checkAutoreopen();
     }
 
     function PurgeLogs() {
@@ -99,6 +105,7 @@ class Cron {
 
         self::MailFetcher();
         self::TicketMonitor();
+        self::TaskMonitor();
         self::PurgeLogs();
         // Run file purging about every 10 cron runs
         if (mt_rand(1, 9) == 4)

--- a/include/class.task.php
+++ b/include/class.task.php
@@ -1165,6 +1165,22 @@ class Task extends TaskModel implements RestrictedAccess, Threadable {
         return !self::lookupIdByNumber($number);
     }
 
+    static function checkAutoreopen() {
+
+        $sql='SELECT id FROM '.TASK_TABLE.' WHERE autoreopen <= NOW() ';
+
+        if(($res=db_query($sql)) && db_num_rows($res)) {
+            while(list($id)=db_fetch_row($res)) {
+                if ($task=Task::lookup($id))
+                {
+                    $errors = array();
+                    $task->setStatus("open", "Automatische Wiederöffnung.", $errors);
+                    db_query("UPDATE ".TASK_TABLE." SET autoreopen = NULL WHERE id = $id");
+                }
+            }
+        }
+   }
+    
     static function create($vars=false) {
         global $thisstaff, $cfg;
 

--- a/include/class.ticket.php
+++ b/include/class.ticket.php
@@ -3621,6 +3621,26 @@ implements RestrictedAccess, Threadable {
 
         }
    }
+   
+   static function checkAutoreopen() {
+
+        $sql='SELECT ticket_id FROM '.TICKET_TABLE.' T1 '
+            .' INNER JOIN '.TICKET_STATUS_TABLE.' status
+                ON (status.id=T1.status_id AND status.state="closed") '
+            .' WHERE autoreopen <= NOW() ';
+
+        if(($res=db_query($sql)) && db_num_rows($res)) {
+            while(list($id)=db_fetch_row($res)) {
+                if ($ticket=Ticket::lookup($id))
+                {
+                    $errors = array();
+                    $status = TicketStatus::lookup(1);
+                    $ticket->setStatus($status, "Automatische Wiederöffnung.", $errors);
+                    db_query("UPDATE ".TICKET_TABLE." SET autoreopen = NULL WHERE ticket_id = $id");
+                }
+            }
+        }
+   }
 
     static function agentActions($agent, $options=array()) {
         if (!$agent)

--- a/include/staff/templates/task-status.tmpl.php
+++ b/include/staff/templates/task-status.tmpl.php
@@ -85,6 +85,31 @@ $action = $info[':action'] ?: ('#tasks/mass/'. $action);
             </tbody>
         </table>
         <hr>
+        <?php if ($info['status'] == "closed"):?>
+        <table>
+            <tr>
+                <td>
+                    <input type="checkbox" name="snooze"/> <?php echo __('Wieder öffnen am:'); ?> 
+                    <input name="reopentime" type="text" class="dp" size=12 placeholder="dd.mm.yyyy"/>
+                    <script type="text/javascript">
+                        $(function() {
+                            $('input[name="reopentime"]').datepicker({
+                                minDate: new Date().getTime(),
+                                numberOfMonths: 2,
+                                showButtonPanel: true,
+                                buttonImage: './images/cal.png',
+                                showOn:'both',
+                                dateFormat: $.translate_format('<?php echo $cfg->getDateFormat(true); ?>')
+                            }).change(function(){
+                                $('input[name="snooze"]').val(true).attr("checked", "checked");
+                            });
+                        });
+                    </script>
+                    <?php echo '&nbsp;' . Misc::timeDropdown($hr, $min, 'reopentime:time');?>
+                </td>
+            </tr>
+        </table>
+        <?php endif;?>
         <p class="full-width">
             <span class="buttons pull-left">
                 <input type="reset" value="<?php echo __('Reset'); ?>">

--- a/include/staff/templates/ticket-status.tmpl.php
+++ b/include/staff/templates/ticket-status.tmpl.php
@@ -93,6 +93,31 @@ $action = $info['action'] ?: ('#tickets/status/'. $state);
             </tbody>
         </table>
         <hr>
+        <?php if ($state == "closed"):?>
+        <table>
+            <tr>
+                <td>
+                    <input type="checkbox" name="snooze"/> <?php echo __('Wieder öffnen am:'); ?> 
+                    <input name="reopentime" type="text" class="dp" size=12 placeholder="dd.mm.yyyy"/>
+                    <script type="text/javascript">
+                        $(function() {
+                            $('input[name="reopentime"]').datepicker({
+                                minDate: new Date().getTime(),
+                                numberOfMonths: 2,
+                                showButtonPanel: true,
+                                buttonImage: './images/cal.png',
+                                showOn:'both',
+                                dateFormat: $.translate_format('<?php echo $cfg->getDateFormat(true); ?>')
+                            }).change(function(){
+                                $('input[name="snooze"]').val(true).attr("checked", "checked");
+                            });
+                        });
+                    </script>
+                    <?php echo '&nbsp;' . Misc::timeDropdown($hr, $min, 'reopentime:time');?>
+                </td>
+            </tr>
+        </table>
+        <?php endif;?>
         <p class="full-width">
             <span class="buttons pull-left">
                 <input type="reset" value="<?php echo __('Reset'); ?>">


### PR DESCRIPTION
This is my first draft of the feature requested in #1959.
# Description
It adds the possibility to automatically reopen a task/ticket at a specific point in time.

![a](https://cloud.githubusercontent.com/assets/1052720/11930871/b6c7304e-a7e7-11e5-997c-fe45af631cef.png)

![b](https://cloud.githubusercontent.com/assets/1052720/11930874/ba9d7642-a7e7-11e5-982d-53325a4cab6a.png)

# Install
In order to use this, you have to add the column autoreopen to ost_ticket and ost_task like

````
ALTER TABLE  `ost_ticket` ADD  `autoreopen` DATETIME NULL DEFAULT NULL;
ALTER TABLE  `ost_task` ADD  `autoreopen` DATETIME NULL DEFAULT NULL;

````

It is based develop-next, but I have some patches from @protich s task-actions branch (https://github.com/protich/osTicket-1.8/tree/feature/task-actions), so it may only work with tickets, not tasks if you add this to develop-next.

# Future
I am not that into the OsTicket codebase, so the code is rather hacky. If someone of the dev-team likes this feature, I think it should be re-implemented in a clean way. At least the database columns have to be created on install/update, but I did not find the place in the code.
However it would be cleaner to add the "autoreopen" as a property of the Task and Ticket objects and allow proper handling through the ORM.
