### PR TITLE
typeahead: The redirect header was emitted too late

### DIFF
--- a/include/staff/tickets.inc.php
+++ b/include/staff/tickets.inc.php
@@ -106,10 +106,6 @@ case 'search':
             $tickets = $__tickets;
             $has_relevance = true;
         }
-        if (count($tickets) == 1) {
-            // Redirect to ticket page
-            Http::redirect('tickets.php?id='.$tickets[0]->getId());
-        }
         // Clear sticky search queue
         unset($_SESSION[$queue_key]);
         break;

--- a/scp/js/scp.js
+++ b/scp/js/scp.js
@@ -270,6 +270,9 @@ var scp_prep = function() {
             var form = $el.closest('form');
             form.find('input[name=search-type]').val('typeahead');
             $el.val(obj.value);
+            if (obj.id) {
+                form.append($('<input type="hidden" name="number">').val(obj.id))
+            }
             form.submit();
         },
         property: "matches"

--- a/scp/tickets.php
+++ b/scp/tickets.php
@@ -27,9 +27,11 @@ $page='';
 $ticket = $user = null; //clean start.
 $redirect = false;
 //LOCKDOWN...See if the id provided is actually valid and if the user has access.
-if($_REQUEST['id']) {
-    if(!($ticket=Ticket::lookup($_REQUEST['id'])))
+if($_REQUEST['id'] || $_REQUEST['number']) {
+    if($_REQUEST['id'] && !($ticket=Ticket::lookup($_REQUEST['id'])))
          $errors['err']=sprintf(__('%s: Unknown or invalid ID.'), __('ticket'));
+    elseif($_REQUEST['number'] && !($ticket=Ticket::lookup(['number' => $_REQUEST['number']])))
+         $errors['err']=sprintf(__('%s: Unknown or invalid number.'), __('ticket'));
     elseif(!$ticket->checkStaffPerm($thisstaff)) {
         $errors['err']=__('Access denied. Contact admin if you believe this is in error');
         $ticket=null; //Clear ticket obj.


### PR DESCRIPTION
This changes the typeahead to redirect directly from the typeahead click rather than redirecting after performing the search a second time on the ticket queue page.

Fixes #2667