### PR TITLE
Fix incorrect Thank-you page being shown issue #2823

### DIFF
--- a/open.php
+++ b/open.php
@@ -73,6 +73,7 @@ require(CLIENTINC_DIR.'header.inc.php');
 if ($ticket
     && (
         (($topic = $ticket->getTopic()) && ($page = $topic->getPage()))
+        || ($page = Page::lookup($topic->getPageId()))
         || ($page = $cfg->getThankYouPage())
     )
 ) {


### PR DESCRIPTION
See https://github.com/osTicket/osTicket-1.8/issues/2823

Thank-you pages configured at a Help Topic level should override the Thank-you pages configured at a Company level.

With this fix, osTicket correctly shows the Thank-you page configured in the Help Topic.