### PR TITLE
Missing global from the function that actually uses it

### DIFF
--- a/include/class.client.php
+++ b/include/class.client.php
@@ -28,8 +28,6 @@ implements EmailContact, ITicketUser, TemplateVariable {
     }
 
     function __call($name, $args) {
-        global $cfg;
-
         $rv = null;
         if($this->user && is_callable(array($this->user, $name)))
             $rv = $args
@@ -53,6 +51,7 @@ implements EmailContact, ITicketUser, TemplateVariable {
     }
 
     function getVar($tag) {
+        global $cfg;
         switch (strtolower($tag)) {
         case 'ticket_link':
             $qstr = array();


### PR DESCRIPTION
Seems to already be fixed in develop, but the global $cfg needs to be in the getVar function in develop-next otherwise we get a fatal error