### PR TITLE
Allow plugins to access $ost global in bootsrap()

### DIFF
--- a/include/class.osticket.php
+++ b/include/class.osticket.php
@@ -495,6 +495,7 @@ class osTicket {
 
     /**** static functions ****/
     function start() {
+    	global $ost;
         // Prep basic translation support
         Internationalization::bootstrap();
 


### PR DESCRIPTION
fix for #2902